### PR TITLE
feat: Issue #2 - DB モデル・マイグレーション

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,12 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
+
+  # Shoulda Matchers for test assertions
+  gem "shoulda-matchers", "~> 5.0"
+
+  # Faker for generating fake data
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
+    faker (3.8.0)
+      i18n (>= 1.8.11, < 2)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.8)
@@ -289,6 +291,8 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    shoulda-matchers (5.3.0)
+      activesupport (>= 5.2.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -358,12 +362,14 @@ DEPENDENCIES
   debug
   devise
   factory_bot_rails
+  faker
   jbuilder
   pg (~> 1.5)
   puma (>= 5.0)
   rails (~> 7.2.3)
   rspec-rails
   rubocop-rails-omakase
+  shoulda-matchers (~> 5.0)
   sprockets-rails
   sqlite3 (>= 1.4)
   tailwindcss-rails
@@ -406,6 +412,7 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
+  faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
@@ -476,6 +483,7 @@ CHECKSUMS
   rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  shoulda-matchers (5.3.0) sha256=f6ba863b8752bb5956aaa73b046d5df5ecfbe9a7acb61f31bf853613e0932f86
   sprockets (4.2.2) sha256=761e5a49f1c288704763f73139763564c845a8f856d52fba013458f8af1b59b1
   sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
   sqlite3 (2.9.3-aarch64-linux-gnu) sha256=ca6dd1cf6c037ccc8d3e5837190cc61ef15466092014951235641b5c4c8ab4ee

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,17 @@
+class Answer < ApplicationRecord
+  belongs_to :question, optional: false
+  belongs_to :user, optional: true
+  belongs_to :choice, optional: true
+
+  validates :body, presence: true
+
+  before_save :set_session_id_hash
+
+  private
+
+  def set_session_id_hash
+    if session_id.present?
+      self.session_id_hash = Digest::SHA256.hexdigest(session_id)
+    end
+  end
+end

--- a/app/models/answer_token.rb
+++ b/app/models/answer_token.rb
@@ -1,0 +1,21 @@
+class AnswerToken < ApplicationRecord
+  belongs_to :question, optional: false
+
+  validates :token, presence: true, uniqueness: true
+
+  before_create :generate_token
+
+  def expired?
+    expires_at.present? && Time.current > expires_at
+  end
+
+  def valid_token?
+    !expired?
+  end
+
+  private
+
+  def generate_token
+    self.token = SecureRandom.hex(32) if token.blank?
+  end
+end

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -1,0 +1,6 @@
+class Choice < ApplicationRecord
+  belongs_to :question, optional: false
+  has_many :answers, dependent: :destroy
+
+  validates :label, presence: true, uniqueness: { scope: :question_id }
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,0 +1,26 @@
+class Question < ApplicationRecord
+  enum question_type: { text: 'text', choice: 'choice', rating: 'rating' }
+  enum status: { draft: 'draft', published: 'published', closed: 'closed' }
+
+  belongs_to :user, optional: false
+  has_many :choices, dependent: :destroy
+  has_many :answers, dependent: :destroy
+
+  validates :title, presence: true
+  validates :body, presence: true
+  validates :question_type, presence: true, inclusion: { in: question_types.keys }
+  validates :status, presence: true, inclusion: { in: statuses.keys }
+
+  def published?
+    status == 'published'
+  end
+
+  def draft?
+    status == 'draft'
+  end
+
+  def closed?
+    status == 'closed'
+  end
+end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,20 @@
+class User < ApplicationRecord
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :validatable
+
+  enum role: { member: 'member', admin: 'admin' }
+
+  has_many :questions, dependent: :destroy
+  has_many :answers, dependent: :destroy
+
+  validates :email, presence: true, uniqueness: true
+  validates :role, presence: true, inclusion: { in: roles.keys }
+
+  def admin?
+    role == 'admin'
+  end
+
+  def member?
+    role == 'member'
+  end
+end

--- a/db/migrate/20260502204652_create_users.rb
+++ b/db/migrate/20260502204652_create_users.rb
@@ -1,0 +1,17 @@
+class CreateUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :users do |t|
+      t.string :email, null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.datetime :remember_created_at
+      t.string :role, default: 'member'
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+    add_index :users, :reset_password_token, unique: true
+  end
+end

--- a/db/migrate/20260502204659_create_questions.rb
+++ b/db/migrate/20260502204659_create_questions.rb
@@ -1,0 +1,14 @@
+class CreateQuestions < ActiveRecord::Migration[7.2]
+  def change
+    create_table :questions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title
+      t.text :body
+      t.string :question_type
+      t.string :status
+      t.datetime :deadline
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260502204700_create_choices.rb
+++ b/db/migrate/20260502204700_create_choices.rb
@@ -1,0 +1,12 @@
+class CreateChoices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :choices do |t|
+      t.references :question, null: false, foreign_key: true
+      t.string :label, null: false
+
+      t.timestamps
+    end
+
+    add_index :choices, [:question_id, :label], unique: true
+  end
+end

--- a/db/migrate/20260502204701_create_answers.rb
+++ b/db/migrate/20260502204701_create_answers.rb
@@ -1,0 +1,17 @@
+class CreateAnswers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :answers do |t|
+      t.references :question, null: false, foreign_key: true
+      t.references :user, null: true, foreign_key: true
+      t.references :choice, null: true, foreign_key: true
+      t.text :body, null: false
+      t.string :session_id
+      t.string :session_id_hash, null: false
+
+      t.timestamps
+    end
+
+    add_index :answers, [:question_id, :session_id_hash], unique: true, name: :index_answers_on_question_and_session_hash
+    add_index :answers, :session_id_hash
+  end
+end

--- a/db/migrate/20260502204702_create_answer_tokens.rb
+++ b/db/migrate/20260502204702_create_answer_tokens.rb
@@ -1,0 +1,13 @@
+class CreateAnswerTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :answer_tokens do |t|
+      t.references :question, null: false, foreign_key: true
+      t.string :token, null: false
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+
+    add_index :answer_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,74 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 0) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_02_204702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "answer_tokens", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.string "token", null: false
+    t.datetime "expires_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id"], name: "index_answer_tokens_on_question_id"
+    t.index ["token"], name: "index_answer_tokens_on_token", unique: true
+  end
+
+  create_table "answers", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.bigint "user_id"
+    t.bigint "choice_id"
+    t.text "body", null: false
+    t.string "session_id"
+    t.string "session_id_hash", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["choice_id"], name: "index_answers_on_choice_id"
+    t.index ["question_id", "session_id_hash"], name: "index_answers_on_question_and_session_hash", unique: true
+    t.index ["question_id"], name: "index_answers_on_question_id"
+    t.index ["session_id_hash"], name: "index_answers_on_session_id_hash"
+    t.index ["user_id"], name: "index_answers_on_user_id"
+  end
+
+  create_table "choices", force: :cascade do |t|
+    t.bigint "question_id", null: false
+    t.string "label", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["question_id", "label"], name: "index_choices_on_question_id_and_label", unique: true
+    t.index ["question_id"], name: "index_choices_on_question_id"
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title"
+    t.text "body"
+    t.string "question_type"
+    t.string "status"
+    t.datetime "deadline"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_questions_on_user_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.string "role", default: "member"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "answer_tokens", "questions"
+  add_foreign_key "answers", "choices"
+  add_foreign_key "answers", "questions"
+  add_foreign_key "answers", "users"
+  add_foreign_key "choices", "questions"
+  add_foreign_key "questions", "users"
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,71 @@
+FactoryBot.define do
+  factory :user do
+    email { Faker::Internet.email }
+    password { 'password123' }
+    password_confirmation { 'password123' }
+    role { 'member' }
+
+    trait :admin do
+      role { 'admin' }
+    end
+
+    trait :member do
+      role { 'member' }
+    end
+  end
+
+  factory :question do
+    user
+    title { Faker::Lorem.sentence(word_count: 5) }
+    body { Faker::Lorem.paragraph(sentence_count: 3) }
+    question_type { 'text' }
+    status { 'draft' }
+    deadline { 7.days.from_now }
+
+    trait :text_type do
+      question_type { 'text' }
+    end
+
+    trait :choice_type do
+      question_type { 'choice' }
+    end
+
+    trait :rating_type do
+      question_type { 'rating' }
+    end
+
+    trait :published do
+      status { 'published' }
+    end
+
+    trait :closed do
+      status { 'closed' }
+    end
+  end
+
+  factory :choice do
+    question
+    label { Faker::Lorem.sentence(word_count: 3) }
+  end
+
+  factory :answer do
+    question
+    user { nil }
+    choice { nil }
+    body { Faker::Lorem.paragraph(sentence_count: 2) }
+    session_id { SecureRandom.hex(16) }
+  end
+
+  factory :answer_token do
+    question
+    expires_at { 30.days.from_now }
+
+    transient do
+      token_value { SecureRandom.hex(32) }
+    end
+
+    after(:build) do |answer_token, evaluator|
+      answer_token.token = evaluator.token_value
+    end
+  end
+end

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe Answer, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:question).optional(false) }
+    it { is_expected.to belong_to(:user).optional(true) }
+    it { is_expected.to belong_to(:choice).optional(true) }
+  end
+
+  describe 'validations' do
+    subject { build(:answer) }
+
+    it { is_expected.to validate_presence_of(:body) }
+  end
+
+  describe 'session_id hashing' do
+    let(:answer) { build(:answer, session_id: 'test-session-123') }
+
+    it 'hashes session_id before save' do
+      answer.save!
+      expect(answer.session_id_hash).not_to be_nil
+      expect(answer.session_id_hash).not_to eq('test-session-123')
+    end
+
+    it 'creates consistent hash for same session_id' do
+      session_id = 'test-session-456'
+      answer1 = build(:answer, session_id: session_id)
+      answer2 = build(:answer, session_id: session_id)
+
+      answer1.save!
+      answer2.save!
+
+      expect(answer1.session_id_hash).to eq(answer2.session_id_hash)
+    end
+  end
+
+  describe '#set_session_id_hash' do
+    it 'hashes the session_id' do
+      answer = build(:answer, session_id: 'abc123')
+      answer.send(:set_session_id_hash)
+      expect(answer.session_id_hash).to be_present
+    end
+  end
+end

--- a/spec/models/answer_token_spec.rb
+++ b/spec/models/answer_token_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe AnswerToken, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:question).optional(false) }
+  end
+
+  describe 'validations' do
+    subject { build(:answer_token) }
+
+    it { is_expected.to validate_presence_of(:token) }
+    it { is_expected.to validate_uniqueness_of(:token) }
+  end
+
+  describe 'token generation' do
+    let(:answer_token) { build(:answer_token) }
+
+    it 'generates a token on create' do
+      answer_token.save!
+      expect(answer_token.token).to be_present
+      expect(answer_token.token.length).to be >= 32
+    end
+  end
+
+  describe '#expired?' do
+    it 'returns false when expires_at is in the future' do
+      answer_token = build(:answer_token, expires_at: Time.current + 1.day)
+      expect(answer_token.expired?).to be false
+    end
+
+    it 'returns true when expires_at is in the past' do
+      answer_token = build(:answer_token, expires_at: Time.current - 1.day)
+      expect(answer_token.expired?).to be true
+    end
+  end
+
+  describe '#valid_token?' do
+    let(:answer_token) { create(:answer_token) }
+
+    it 'returns true for valid non-expired token' do
+      expect(answer_token.valid_token?).to be true
+    end
+
+    it 'returns false for expired token' do
+      answer_token.update(expires_at: Time.current - 1.day)
+      expect(answer_token.valid_token?).to be false
+    end
+  end
+end

--- a/spec/models/choice_spec.rb
+++ b/spec/models/choice_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe Choice, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:question).optional(false) }
+    it { is_expected.to have_many(:answers).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    subject { build(:choice) }
+
+    it { is_expected.to validate_presence_of(:label) }
+  end
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe Question, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user).optional(false) }
+    it { is_expected.to have_many(:choices).dependent(:destroy) }
+    it { is_expected.to have_many(:answers).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    subject { build(:question) }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:body) }
+    it { is_expected.to validate_presence_of(:question_type) }
+    it { is_expected.to validate_presence_of(:status) }
+  end
+
+  describe '#published?' do
+    it 'returns true when status is published' do
+      question = build(:question, status: 'published')
+      expect(question.published?).to be true
+    end
+  end
+
+  describe '#draft?' do
+    it 'returns true when status is draft' do
+      question = build(:question, status: 'draft')
+      expect(question.draft?).to be true
+    end
+  end
+
+  describe '#closed?' do
+    it 'returns true when status is closed' do
+      question = build(:question, status: 'closed')
+      expect(question.closed?).to be true
+    end
+  end
+end
+

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe User, type: :model do
+  describe 'associations' do
+    it { is_expected.to have_many(:questions).dependent(:destroy) }
+    it { is_expected.to have_many(:answers).dependent(:destroy) }
+  end
+
+  describe 'validations' do
+    subject { build(:user) }
+
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_presence_of(:role) }
+
+    it 'does not allow duplicate email' do
+      user1 = create(:user, email: 'test@example.com')
+      user2 = build(:user, email: 'test@example.com')
+      expect(user2).not_to be_valid
+    end
+  end
+
+  describe '#admin?' do
+    it 'returns true when role is admin' do
+      user = build(:user, role: 'admin')
+      expect(user.admin?).to be true
+    end
+
+    it 'returns false when role is not admin' do
+      user = build(:user, role: 'member')
+      expect(user.admin?).to be false
+    end
+  end
+
+  describe '#member?' do
+    it 'returns true when role is member' do
+      user = build(:user, role: 'member')
+      expect(user.member?).to be true
+    end
+
+    it 'returns false when role is not member' do
+      user = build(:user, role: 'admin')
+      expect(user.member?).to be false
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,9 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require 'factory_bot_rails'
+require 'shoulda-matchers'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -48,6 +51,9 @@ RSpec.configure do |config|
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
+  # FactoryBot setup
+  config.include FactoryBot::Syntax::Methods
+
   # RSpec Rails uses metadata to mix in different behaviours to your tests,
   # for example enabling you to call `get` and `post` in request specs. e.g.:
   #
@@ -69,4 +75,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end


### PR DESCRIPTION
## 概要
Issue #2 に沿って、User, Question, Choice, Answer, AnswerToken モデルおよびマイグレーションを実装

## 作業内容
- User モデル：Devise 認証統合、role カラム（admin/member）
- Question モデル：title, body, question_type, status, deadline
- Choice モデル：Question への関連付け
- Answer モデル：Question, User, Choice への関連付け、セッション ID SHA256 ハッシュ化
- AnswerToken モデル：トークン・有効期限管理
- 5つのマイグレーション：users, questions, choices, answers, answer_tokens テーブル作成
- 重要なインデックス：session_id_hash の一意性、token の一意性

## テスト
- RSpec テストスイート：37 examples すべて成功
- shoulda-matchers による associations・validations テスト
- FactoryBot による テストデータ生成
- Faker による ダミーデータ生成

## テスト実行結果
✅ 37 examples, 0 failures

## 関連 Issue
Closes #2