### PR TITLE
feat: Issue #3 - Seed データ・初期化

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,117 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
-# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+# Seed データ・初期化スクリプト
+
+# 既存データをクリア
+User.delete_all
+Question.delete_all
+Choice.delete_all
+Answer.delete_all
+AnswerToken.delete_all
+
+# IDカウンターをリセット
+if ActiveRecord::Base.connection.adapter_name.downcase.include?('postgres')
+  ActiveRecord::Base.connection.reset_pk_sequence!(:users)
+  ActiveRecord::Base.connection.reset_pk_sequence!(:questions)
+  ActiveRecord::Base.connection.reset_pk_sequence!(:choices)
+  ActiveRecord::Base.connection.reset_pk_sequence!(:answers)
+  ActiveRecord::Base.connection.reset_pk_sequence!(:answer_tokens)
+end
+
+puts '=== Seed データ生成を開始 ==='
+
+# ==========================================
+# 1. 管理者ユーザー作成
+# ==========================================
+admin = User.create!(
+  email: 'admin@honest-voice.local',
+  password: 'HonestVoice123!',
+  password_confirmation: 'HonestVoice123!',
+  role: :admin
+)
+puts "✓ 管理者ユーザー作成: #{admin.email}"
+
+# ==========================================
+# 2. 従業員ユーザー作成（3名）
+# ==========================================
+member_emails = [
+  'member1@honest-voice.local',
+  'member2@honest-voice.local',
+  'member3@honest-voice.local'
+]
+
+members = member_emails.map do |email|
+  User.create!(
+    email: email,
+    password: 'HonestVoice123!',
+    password_confirmation: 'HonestVoice123!',
+    role: :member
+  )
+end
+puts "✓ 従業員ユーザー作成: #{members.count}名"
+
+# ==========================================
+# 3. サンプル質問作成
+# ==========================================
+
+# テキスト型質問
+q1 = Question.create!(
+  user_id: admin.id,
+  title: '今月で改善されたと感じたことを教えてください',
+  body: '組織の改善に繋がった内容があれば、具体的にお書きください',
+  question_type: :text,
+  status: :published,
+  deadline: 1.week.from_now
+)
+puts "✓ テキスト型質問作成: #{q1.title}"
+
+# 選択肢型質問
+q2 = Question.create!(
+  user_id: admin.id,
+  title: 'あなたの職場環境について評価してください',
+  body: 'チームの雰囲気をお選びください',
+  question_type: :choice,
+  status: :published,
+  deadline: 10.days.from_now
+)
+
+# 選択肢を追加
+choice_labels = ['非常に良好', '良好', '普通', '改善が必要', '大きな問題がある']
+choice_labels.each do |label|
+  Choice.create!(
+    question_id: q2.id,
+    label: label
+  )
+end
+puts "✓ 選択肢型質問作成: #{q2.title}（選択肢数: #{q2.choices.count}）"
+
+# レーティング型質問
+q3 = Question.create!(
+  user_id: admin.id,
+  title: '今月の社内コミュニケーション満足度を教えてください',
+  body: '1〜5の範囲で評価してください（1: 非常に不満、5: 非常に満足）',
+  question_type: :rating,
+  status: :published,
+  deadline: 5.days.from_now
+)
+puts "✓ レーティング型質問作成: #{q3.title}"
+
+# テキスト型質問（2つ目）
+q4 = Question.create!(
+  user_id: admin.id,
+  title: '次年度の会社方針についてのご意見をお聞かせください',
+  body: '会社の方向性や戦略についての率直なご意見をお願いします',
+  question_type: :text,
+  status: :published,
+  deadline: 15.days.from_now
+)
+puts "✓ テキスト型質問作成: #{q4.title}"
+
+# ==========================================
+# 完了メッセージ
+# ==========================================
+puts "\n✅ Seed データ生成完了！"
+puts "  - ユーザー数: #{User.count}名（管理者: 1, 従業員: 3）"
+puts "  - 質問数: #{Question.count}件"
+puts "    - テキスト型: #{Question.where(question_type: :text).count}件"
+puts "    - 選択肢型: #{Question.where(question_type: :choice).count}件"
+puts "    - レーティング型: #{Question.where(question_type: :rating).count}件"
+puts "  - 選択肢数: #{Choice.count}個"

--- a/spec/seeds/seed_spec.rb
+++ b/spec/seeds/seed_spec.rb
@@ -1,0 +1,91 @@
+require 'rails_helper'
+
+RSpec.describe 'Seed data' do
+  before do
+    # データベースをクリアしてから seed を実行
+    User.delete_all
+    Question.delete_all
+    Choice.delete_all
+    Answer.delete_all
+    AnswerToken.delete_all
+    
+    # Seed スクリプト読み込みと実行
+    load Rails.root.join('db', 'seeds.rb')
+  end
+
+  describe 'Users' do
+    it '管理者ユーザーが1名作成される' do
+      admin_user = User.find_by(role: :admin)
+      expect(admin_user).not_to be_nil
+      expect(admin_user.admin?).to be true
+    end
+
+    it '従業員ユーザーが3名作成される' do
+      member_users = User.where(role: :member)
+      expect(member_users.count).to eq(3)
+      expect(member_users.all?(&:member?)).to be true
+    end
+
+    it 'すべてのユーザーが有効なメールアドレスを持つ' do
+      expect(User.all.all? { |user| user.email.present? && user.email.include?('@') }).to be true
+    end
+
+    it 'ユーザー数が4名である' do
+      expect(User.count).to eq(4)
+    end
+  end
+
+  describe 'Questions' do
+    it 'サンプル質問が複数作成される' do
+      expect(Question.count).to be > 0
+    end
+
+    it 'テキスト型質問が存在する' do
+      text_questions = Question.where(question_type: :text)
+      expect(text_questions.exists?).to be true
+    end
+
+    it '選択肢型質問が存在する' do
+      choice_questions = Question.where(question_type: :choice)
+      expect(choice_questions.exists?).to be true
+    end
+
+    it 'レーティング型質問が存在する' do
+      rating_questions = Question.where(question_type: :rating)
+      expect(rating_questions.exists?).to be true
+    end
+
+    it 'すべての質問が admin ユーザーに属する' do
+      admin_user = User.find_by(role: :admin)
+      expect(Question.all.all? { |q| q.user_id == admin_user.id }).to be true
+    end
+
+    it 'すべての質問が title を持つ' do
+      expect(Question.all.all? { |q| q.title.present? }).to be true
+    end
+
+    it 'すべての質問が body を持つ' do
+      expect(Question.all.all? { |q| q.body.present? }).to be true
+    end
+
+    it 'すべての質問が published status である' do
+      expect(Question.all.all? { |q| q.published? }).to be true
+    end
+  end
+
+  describe 'Choices' do
+    it '選択肢型質問に複数の選択肢が作成される' do
+      choice_questions = Question.where(question_type: :choice)
+      choice_questions.each do |question|
+        expect(question.choices.count).to be > 0
+      end
+    end
+
+    it 'テキスト型質問には選択肢がない' do
+      text_questions = Question.where(question_type: :text)
+      text_questions.each do |question|
+        expect(question.choices.count).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #3 に沿って、管理者ユーザー、従業員ユーザー、サンプル質問データを作成する Seed スクリプトを実装

## 作業内容

- db/seeds.rb ファイル実装
  - 管理者ユーザー作成（1名）
  - 従業員ユーザー作成（3名）
  - サンプル質問作成（複数タイプ）
    - テキスト型質問 2件
    - 選択肢型質問 1件（選択肢 5個）
    - レーティング型質問 1件

## テスト

- RSpec による Seed データバリデーション
  - ユーザー数・ロール確認
  - 質問データ構造確認
  - 質問タイプ確認
  - 選択肢確認

## テスト実行結果

✅ 14 examples, 0 failures

## 実行方法

rails db:seed でテスト実行

## 関連 Issue

Closes #3