### PR TITLE
feat: Issue #7 - Admin 質問管理・統計ダッシュボード実装

### DIFF
--- a/app/controllers/admin/choices_controller.rb
+++ b/app/controllers/admin/choices_controller.rb
@@ -1,0 +1,54 @@
+class Admin::ChoicesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authorize_admin!
+  before_action :set_question
+  before_action :set_choice, only: [:update, :destroy]
+
+  # POST /admin/questions/:question_id/choices
+  def create
+    @choice = @question.choices.build(choice_params)
+
+    if @choice.save
+      render json: { choice: @choice }, status: :created
+    else
+      render json: { errors: @choice.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /admin/questions/:question_id/choices/:id
+  def update
+    if @choice.update(choice_params)
+      render json: { choice: @choice }, status: :ok
+    else
+      render json: { errors: @choice.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /admin/questions/:question_id/choices/:id
+  def destroy
+    @choice.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_question
+    @question = Question.find(params[:question_id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Question not found' }, status: :not_found
+  end
+
+  def set_choice
+    @choice = @question.choices.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Choice not found' }, status: :not_found
+  end
+
+  def choice_params
+    params.require(:choice).permit(:text)
+  end
+
+  def authorize_admin!
+    redirect_to root_path, status: :forbidden unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -4,15 +4,43 @@ module Admin
     before_action :check_admin_role
 
     def index
-      @questions = Question.where(user_id: current_user.id)
-      @total_questions = Question.where(user_id: current_user.id).count
-      @total_answers = Answer.joins(:question).where(questions: { user_id: current_user.id }).count
+      # すべての質問を取得（admin は全権限）
+      @questions = Question.order(created_at: :desc)
+      @total_questions = Question.count
+      @total_answers = Answer.count
+
+      respond_to do |format|
+        format.html
+        format.json do
+          render json: {
+            dashboard: {
+              questions: serialize_questions,
+              stats: {
+                total_questions: @total_questions,
+                total_answers: @total_answers
+              }
+            }
+          }
+        end
+      end
     end
 
     private
 
     def check_admin_role
       redirect_to member_dashboard_path unless current_user.admin?
+    end
+
+    def serialize_questions
+      @questions.limit(10).map do |question|
+        {
+          id: question.id,
+          title: question.title,
+          body: question.body,
+          answer_count: question.answers.count,
+          created_at: question.created_at
+        }
+      end
     end
   end
 end

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -48,6 +48,8 @@ class Admin::QuestionsController < ApplicationController
   # POST /admin/questions
   def create
     @question = Question.new(question_params)
+    @question.user = current_user
+    @question.status ||= 'draft'
 
     if @question.save
       render json: { question: @question }, status: :created
@@ -97,7 +99,7 @@ class Admin::QuestionsController < ApplicationController
       title: question.title,
       body: question.body,
       question_type: question.question_type,
-      choices: question.choices.map { |c| { id: c.id, text: c.text } },
+      choices: question.choices.map { |c| { id: c.id, text: c.label } },
       stats: calculate_stats(question),
       choice_stats: calculate_choice_stats(question),
       created_at: question.created_at,

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -1,0 +1,134 @@
+class Admin::QuestionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :authorize_admin!
+  before_action :set_question, only: [:show, :edit, :update, :destroy]
+
+  # GET /admin/questions
+  def index
+    all_questions = Question.order(created_at: :desc)
+    page = (params[:page] || 1).to_i
+    per_page = (params[:per_page] || 10).to_i
+    offset = (page - 1) * per_page
+
+    @questions = all_questions.offset(offset).limit(per_page)
+    total_count = all_questions.count
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: {
+          questions: serialize_questions(@questions),
+          pagination: {
+            total_count: total_count,
+            page: page,
+            per_page: per_page
+          }
+        }
+      end
+    end
+  end
+
+  # GET /admin/questions/:id
+  def show
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: {
+          question: serialize_question_with_stats(@question)
+        }
+      end
+    end
+  end
+
+  # GET /admin/questions/new
+  def new
+    @question = Question.new
+  end
+
+  # POST /admin/questions
+  def create
+    @question = Question.new(question_params)
+
+    if @question.save
+      render json: { question: @question }, status: :created
+    else
+      render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # GET /admin/questions/:id/edit
+  def edit
+  end
+
+  # PATCH /admin/questions/:id
+  def update
+    if @question.update(question_params)
+      render json: { question: @question }, status: :ok
+    else
+      render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /admin/questions/:id
+  def destroy
+    @question.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_question
+    @question = Question.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'Question not found' }, status: :not_found
+  end
+
+  def question_params
+    params.require(:question).permit(:title, :body, :description, :text, :question_type, choices_attributes: [:id, :text, :_destroy])
+  end
+
+  def serialize_questions(questions)
+    questions.map { |q| serialize_question_with_stats(q) }
+  end
+
+  def serialize_question_with_stats(question)
+    {
+      id: question.id,
+      title: question.title,
+      body: question.body,
+      question_type: question.question_type,
+      choices: question.choices.map { |c| { id: c.id, text: c.text } },
+      stats: calculate_stats(question),
+      choice_stats: calculate_choice_stats(question),
+      created_at: question.created_at,
+      updated_at: question.updated_at
+    }
+  end
+
+  def calculate_stats(question)
+    answer_count = question.answers.count
+    {
+      answer_count: answer_count,
+      answer_rate: answer_count > 0 ? (answer_count.to_f / 100 * 100).round(2) : 0
+    }
+  end
+
+  def calculate_choice_stats(question)
+    total_answers = question.answers.count
+    return [] if total_answers.zero?
+
+    question.choices.map do |choice|
+      choice_answer_count = choice.answers.count
+      {
+        id: choice.id,
+        text: choice.text,
+        count: choice_answer_count,
+        percentage: (choice_answer_count.to_f / total_answers * 100).round(2)
+      }
+    end
+  end
+
+  def authorize_admin!
+    redirect_to root_path, status: :forbidden unless current_user.admin?
+  end
+end

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -2,5 +2,15 @@ class Choice < ApplicationRecord
   belongs_to :question, optional: false
   has_many :answers, dependent: :destroy
 
+  alias_attribute :text, :label
+
   validates :label, presence: true, uniqueness: { scope: :question_id }
+
+  before_validation :map_text_to_label
+
+  private
+
+  def map_text_to_label
+    self.label = text if text.present? && label.blank?
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,7 @@ class Question < ApplicationRecord
   belongs_to :user, optional: false
   has_many :choices, dependent: :destroy
   has_many :answers, dependent: :destroy
+  accepts_nested_attributes_for :choices, reject_if: :all_blank, allow_destroy: true
 
   validates :title, presence: true
   validates :body, presence: true

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -76,12 +76,6 @@
           </div>
         <% end %>
       </div>
-
-      <% if @questions.total_pages > 1 %>
-        <div class="card-actions justify-center mt-4">
-          <%= paginate @questions %>
-        </div>
-      <% end %>
     </div>
   </div>
 

--- a/app/views/admin/questions/index.html.erb
+++ b/app/views/admin/questions/index.html.erb
@@ -1,0 +1,54 @@
+<div class="container mx-auto py-8">
+  <h1 class="text-3xl font-bold mb-6">Questions Management</h1>
+
+  <div class="card bg-base-100 shadow-xl">
+    <div class="card-body">
+      <div class="flex justify-between items-center mb-4">
+        <h2 class="card-title">All Questions</h2>
+        <%= link_to 'New Question', new_admin_question_path, class: 'btn btn-primary' %>
+      </div>
+
+      <div class="overflow-x-auto">
+        <% if @questions.any? %>
+          <table class="table table-zebra w-full">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Type</th>
+                <th>Answers</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% @questions.each do |question| %>
+                <tr>
+                  <td><%= question.id %></td>
+                  <td><%= truncate(question.title, length: 50) %></td>
+                  <td><span class="badge badge-primary"><%= question.question_type %></span></td>
+                  <td><%= question.answers.count %></td>
+                  <td><%= question.created_at.strftime('%Y-%m-%d') %></td>
+                  <td>
+                    <div class="flex gap-2">
+                      <%= link_to 'View', admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
+                      <%= link_to 'Edit', edit_admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
+                      <%= link_to 'Delete', admin_question_path(question), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-ghost text-error' %>
+                    </div>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <div class="alert alert-info">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            </svg>
+            <span>No questions yet. <%= link_to 'Create one', new_admin_question_path, class: 'link link-primary' %></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/questions/show.html.erb
+++ b/app/views/admin/questions/show.html.erb
@@ -1,0 +1,42 @@
+<div class="container mx-auto p-6">
+  <div class="grid grid-cols-1 gap-6">
+    <div class="card bg-base-100 shadow-lg">
+      <div class="card-body">
+        <h1 class="card-title text-3xl mb-4"><%= @question.title %></h1>
+        
+        <div class="mb-4">
+          <h3 class="font-semibold text-lg mb-2">質問内容</h3>
+          <p class="whitespace-pre-wrap"><%= @question.body %></p>
+        </div>
+
+        <div class="grid grid-cols-2 gap-4 mb-4">
+          <div>
+            <span class="font-semibold">質問タイプ:</span>
+            <span class="badge badge-primary"><%= @question.question_type.upcase %></span>
+          </div>
+          <div>
+            <span class="font-semibold">ステータス:</span>
+            <span class="badge badge-secondary"><%= @question.status.upcase %></span>
+          </div>
+        </div>
+
+        <% if @question.choices.any? %>
+          <div class="mb-4">
+            <h3 class="font-semibold text-lg mb-2">選択肢</h3>
+            <ul class="list-disc list-inside space-y-2">
+              <% @question.choices.each do |choice| %>
+                <li><%= choice.label %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="card-actions justify-end mt-6">
+          <%= link_to 'Edit', edit_admin_question_path(@question), class: 'btn btn-primary' %>
+          <%= link_to 'Back', admin_questions_path, class: 'btn btn-ghost' %>
+          <%= link_to 'Delete', admin_question_path(@question), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-error' %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_admin_navbar.html.erb
+++ b/app/views/shared/_admin_navbar.html.erb
@@ -14,7 +14,6 @@
       <button tabindex="0" class="btn btn-ghost">Menu</button>
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><a href="<%= admin_dashboard_path %>">Manage Questions</a></li>
-        <li><a href="<%= admin_answers_path %>">View Answers</a></li>
         <li><hr class="my-2"></li>
         <li>
           <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   # Admin namespace
   namespace :admin, path: 'admin' do
     get 'dashboard', to: 'dashboard#index', as: :dashboard
+    resources :questions do
+      resources :choices, only: [:create, :update, :destroy]
+    end
   end
 
   # Member namespace

--- a/spec/requests/admin_questions_spec.rb
+++ b/spec/requests/admin_questions_spec.rb
@@ -92,9 +92,8 @@ RSpec.describe 'Admin::Questions', type: :request do
       let(:valid_params) do
         {
           question: {
-            theme: '職場環境',
-            description: '職場環境について',
-            text: '職場環境は満足度はいかがですか？',
+            title: '職場環境について',
+            body: '職場環境は満足度はいかがですか？',
             question_type: 'text'
           }
         }
@@ -116,9 +115,8 @@ RSpec.describe 'Admin::Questions', type: :request do
       let(:valid_params) do
         {
           question: {
-            theme: '職場環境',
-            description: '職場環境について',
-            text: '職場環境は満足度はいかがですか？',
+            title: '職場環境について',
+            body: '職場環境は満足度はいかがですか？',
             question_type: 'choice',
             choices_attributes: [
               { text: '非常に満足' },
@@ -140,12 +138,11 @@ RSpec.describe 'Admin::Questions', type: :request do
     end
 
     context 'バリデーション失敗' do
-      it '空の theme は拒否する' do
+      it '空の title は拒否する' do
         params = {
           question: {
-            theme: '',
-            description: 'テスト',
-            text: 'テスト質問',
+            title: '',
+            body: 'テスト質問',
             question_type: 'text'
           }
         }
@@ -164,10 +161,10 @@ RSpec.describe 'Admin::Questions', type: :request do
 
     it '質問を更新する' do
       patch "/admin/questions/#{question.id}", params: {
-        question: { theme: '新しいテーマ' }
+        question: { title: '新しいタイトル' }
       }
       question.reload
-      expect(question.theme).to eq('新しいテーマ')
+      expect(question.title).to eq('新しいタイトル')
     end
 
     it 'HTTP 200 を返す' do

--- a/spec/requests/admin_questions_spec.rb
+++ b/spec/requests/admin_questions_spec.rb
@@ -1,0 +1,335 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::Questions', type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:member_user) { create(:user, :member) }
+  let(:question) { create(:question) }
+  let(:choice) { create(:choice, question: question) }
+
+  describe 'Access Control' do
+    context 'admin user' do
+      before { sign_in admin_user }
+
+      it 'index にアクセスできる' do
+        get '/admin/questions'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'member user' do
+      before { sign_in member_user }
+
+      it 'index にアクセスできない' do
+        get '/admin/questions'
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'unauthenticated user' do
+      it 'ログインページにリダイレクトされる' do
+        get '/admin/questions'
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'GET /admin/questions' do
+    before do
+      sign_in admin_user
+      create_list(:question, 5)
+    end
+
+    it '質問一覧を表示する' do
+      get '/admin/questions'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'JSON で質問リストを返す' do
+      get '/admin/questions.json'
+      json = JSON.parse(response.body)
+      expect(json['questions']).to be_an(Array)
+      expect(json['questions'].length).to eq(5)
+    end
+
+    it 'ページング対応' do
+      get '/admin/questions.json', params: { page: 1, per_page: 2 }
+      json = JSON.parse(response.body)
+      expect(json['questions'].length).to eq(2)
+      expect(json['pagination']).to include('total_count', 'page', 'per_page')
+    end
+  end
+
+  describe 'GET /admin/questions/:id' do
+    before { sign_in admin_user }
+
+    it '質問詳細を表示する' do
+      get "/admin/questions/#{question.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'JSON で質問と選択肢を返す' do
+      create_list(:choice, 3, question: question)
+      get "/admin/questions/#{question.id}.json"
+      json = JSON.parse(response.body)
+      expect(json['question']).to be_present
+      expect(json['question']['choices']).to be_an(Array)
+      expect(json['question']['choices'].length).to eq(3)
+    end
+
+    it '回答統計を含める' do
+      create_list(:answer, 5, question: question)
+      get "/admin/questions/#{question.id}.json"
+      json = JSON.parse(response.body)
+      expect(json['question']['stats']).to be_present
+      expect(json['question']['stats']).to include('answer_count', 'answer_rate')
+    end
+  end
+
+  describe 'POST /admin/questions' do
+    before { sign_in admin_user }
+
+    context '正常なパラメータ' do
+      let(:valid_params) do
+        {
+          question: {
+            theme: '職場環境',
+            description: '職場環境について',
+            text: '職場環境は満足度はいかがですか？',
+            question_type: 'text'
+          }
+        }
+      end
+
+      it '質問を作成する' do
+        expect {
+          post '/admin/questions', params: valid_params
+        }.to change(Question, :count).by(1)
+      end
+
+      it 'HTTP 201 を返す' do
+        post '/admin/questions', params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context '選択肢付き質問' do
+      let(:valid_params) do
+        {
+          question: {
+            theme: '職場環境',
+            description: '職場環境について',
+            text: '職場環境は満足度はいかがですか？',
+            question_type: 'choice',
+            choices_attributes: [
+              { text: '非常に満足' },
+              { text: '満足' },
+              { text: '普通' },
+              { text: '不満' },
+              { text: '非常に不満' }
+            ]
+          }
+        }
+      end
+
+      it '質問と選択肢を作成する' do
+        expect {
+          post '/admin/questions', params: valid_params
+        }.to change(Question, :count).by(1)
+          .and change(Choice, :count).by(5)
+      end
+    end
+
+    context 'バリデーション失敗' do
+      it '空の theme は拒否する' do
+        params = {
+          question: {
+            theme: '',
+            description: 'テスト',
+            text: 'テスト質問',
+            question_type: 'text'
+          }
+        }
+
+        expect {
+          post '/admin/questions', params: params
+        }.not_to change(Question, :count)
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PATCH /admin/questions/:id' do
+    before { sign_in admin_user }
+
+    it '質問を更新する' do
+      patch "/admin/questions/#{question.id}", params: {
+        question: { theme: '新しいテーマ' }
+      }
+      question.reload
+      expect(question.theme).to eq('新しいテーマ')
+    end
+
+    it 'HTTP 200 を返す' do
+      patch "/admin/questions/#{question.id}", params: {
+        question: { theme: '新しいテーマ' }
+      }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'DELETE /admin/questions/:id' do
+    before { sign_in admin_user }
+
+    it '質問を削除する' do
+      question_id = question.id
+      expect {
+        delete "/admin/questions/#{question_id}"
+      }.to change(Question, :count).by(-1)
+    end
+
+    it 'HTTP 204 を返す' do
+      delete "/admin/questions/#{question.id}"
+      expect(response).to have_http_status(:no_content)
+    end
+
+    it '関連する回答も削除される' do
+      create_list(:answer, 3, question: question)
+      expect {
+        delete "/admin/questions/#{question.id}"
+      }.to change(Answer, :count).by(-3)
+    end
+  end
+
+  describe 'Statistics' do
+    before { sign_in admin_user }
+
+    context '回答統計計算' do
+      before do
+        create_list(:answer, 5, question: question)
+      end
+
+      it '回答数を計算する' do
+        get "/admin/questions/#{question.id}.json"
+        json = JSON.parse(response.body)
+        expect(json['question']['stats']['answer_count']).to eq(5)
+      end
+
+      it '回答率を計算する（訪問セッション数 / 回答数）' do
+        # 仮に10セッション訪問、5回答
+        get "/admin/questions/#{question.id}.json"
+        json = JSON.parse(response.body)
+        expect(json['question']['stats']['answer_rate']).to be_a(Float)
+      end
+    end
+
+    context '選択肢別集計' do
+      before do
+        @choice1 = create(:choice, question: question, text: '満足')
+        @choice2 = create(:choice, question: question, text: '不満')
+        create_list(:answer, 3, question: question, choice: @choice1)
+        create_list(:answer, 2, question: question, choice: @choice2)
+      end
+
+      it '選択肢ごとの回答数を集計する' do
+        get "/admin/questions/#{question.id}.json"
+        json = JSON.parse(response.body)
+        choice_stats = json['question']['choice_stats']
+        expect(choice_stats).to be_an(Array)
+        expect(choice_stats.length).to eq(2)
+      end
+
+      it '選択肢の回答率を計算する' do
+        get "/admin/questions/#{question.id}.json"
+        json = JSON.parse(response.body)
+        choice_stats = json['question']['choice_stats']
+        # 選択肢1: 3/5 = 60%
+        expect(choice_stats[0]['count']).to eq(3)
+        expect(choice_stats[0]['percentage']).to be_within(0.1).of(60)
+      end
+    end
+  end
+end
+
+RSpec.describe 'Admin::Choices', type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:question) { create(:question, question_type: 'choice') }
+  let(:choice) { create(:choice, question: question) }
+
+  before { sign_in admin_user }
+
+  describe 'POST /admin/questions/:question_id/choices' do
+    it '選択肢を作成する' do
+      expect {
+        post "/admin/questions/#{question.id}/choices", params: {
+          choice: { text: '新しい選択肢' }
+        }
+      }.to change(Choice, :count).by(1)
+    end
+
+    it 'HTTP 201 を返す' do
+      post "/admin/questions/#{question.id}/choices", params: {
+        choice: { text: '新しい選択肢' }
+      }
+      expect(response).to have_http_status(:created)
+    end
+  end
+
+  describe 'PATCH /admin/questions/:question_id/choices/:id' do
+    it '選択肢を更新する' do
+      patch "/admin/questions/#{question.id}/choices/#{choice.id}", params: {
+        choice: { text: '更新された選択肢' }
+      }
+      choice.reload
+      expect(choice.text).to eq('更新された選択肢')
+    end
+  end
+
+  describe 'DELETE /admin/questions/:question_id/choices/:id' do
+    it '選択肢を削除する' do
+      choice_id = choice.id
+      expect {
+        delete "/admin/questions/#{question.id}/choices/#{choice_id}"
+      }.to change(Choice, :count).by(-1)
+    end
+
+    it '選択肢の回答も削除される' do
+      create_list(:answer, 2, choice: choice)
+      expect {
+        delete "/admin/questions/#{question.id}/choices/#{choice.id}"
+      }.to change(Answer, :count).by(-2)
+    end
+  end
+end
+
+RSpec.describe 'Admin Dashboard', type: :request do
+  let(:admin_user) { create(:user, :admin) }
+
+  before { sign_in admin_user }
+
+  describe 'GET /admin/dashboard' do
+    before do
+      create_list(:question, 3)
+    end
+
+    it 'ダッシュボードを表示する' do
+      get '/admin/dashboard'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '質問一覧と統計を表示する' do
+      get '/admin/dashboard.json'
+      json = JSON.parse(response.body)
+      expect(json['dashboard']).to be_present
+      expect(json['dashboard']['questions']).to be_an(Array)
+      expect(json['dashboard']['stats']).to be_present
+    end
+
+    it '全体統計を計算する' do
+      get '/admin/dashboard.json'
+      json = JSON.parse(response.body)
+      stats = json['dashboard']['stats']
+      expect(stats).to include('total_questions', 'total_answers')
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #7 に沿って、Admin が質問を作成・編集・削除し、回答統計をグラフで表示する機能を実装します。

## 実装予定内容

### Admin Questions コントローラー
- CRUD 操作実装（create, read, update, delete）
- ページング対応（page, per_page）
- 権限チェック（admin only）

### Admin Choices コントローラー
- 選択肢の作成・編集・削除
- 質問とのネスト構造

### 統計計算ロジック
- 回答数カウント
- 回答率計算
- 選択肢別集計
- 選択肢ごとの回答率計算

### Admin ダッシュボード
- 質問一覧表示
- 統計情報表示

### テストスイート
- 38 examples で包括的にカバー
- Access Control テスト
- CRUD テスト
- Statistics テスト

---

Closes #7