### PR TITLE
fix: 不備修正（回答導線・管理画面テンプレート・評価UI改善）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,8 @@ pickle-email-*.html
 
 # JavaScript / esbuild
 node_modules/
-app/assets/builds/
+app/assets/builds/*
+!app/assets/builds/.keep
 .eslintcache
 .idea/
 *.swp

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_tree ../builds
+//= link application.css

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -52,9 +52,15 @@ class Admin::QuestionsController < ApplicationController
     @question.status ||= 'draft'
 
     if @question.save
-      render json: { question: serialize_question_with_stats(@question) }, status: :created
+      respond_to do |format|
+        format.html { redirect_to admin_question_path(@question), notice: '質問を作成しました。' }
+        format.json { render json: { question: serialize_question_with_stats(@question) }, status: :created }
+      end
     else
-      render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
+      respond_to do |format|
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 
@@ -65,9 +71,15 @@ class Admin::QuestionsController < ApplicationController
   # PATCH /admin/questions/:id
   def update
     if @question.update(question_params)
-      render json: { question: @question }, status: :ok
+      respond_to do |format|
+        format.html { redirect_to admin_question_path(@question), notice: '質問を更新しました。' }
+        format.json { render json: { question: @question }, status: :ok }
+      end
     else
-      render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
+      respond_to do |format|
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 
@@ -82,7 +94,10 @@ class Admin::QuestionsController < ApplicationController
   def set_question
     @question = Question.find(params[:id])
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Question not found' }, status: :not_found
+    respond_to do |format|
+      format.html { redirect_to admin_questions_path, alert: '質問が見つかりませんでした。' }
+      format.json { render json: { error: 'Question not found' }, status: :not_found }
+    end
   end
 
   def question_params

--- a/app/controllers/admin/questions_controller.rb
+++ b/app/controllers/admin/questions_controller.rb
@@ -52,14 +52,16 @@ class Admin::QuestionsController < ApplicationController
     @question.status ||= 'draft'
 
     if @question.save
-      respond_to do |format|
-        format.html { redirect_to admin_question_path(@question), notice: '質問を作成しました。' }
-        format.json { render json: { question: serialize_question_with_stats(@question) }, status: :created }
+      if html_form_request?
+        redirect_to admin_question_path(@question), notice: '質問を作成しました。'
+      else
+        render json: { question: serialize_question_with_stats(@question) }, status: :created
       end
     else
-      respond_to do |format|
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity }
+      if html_form_request?
+        render :new, status: :unprocessable_entity
+      else
+        render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
       end
     end
   end
@@ -71,14 +73,16 @@ class Admin::QuestionsController < ApplicationController
   # PATCH /admin/questions/:id
   def update
     if @question.update(question_params)
-      respond_to do |format|
-        format.html { redirect_to admin_question_path(@question), notice: '質問を更新しました。' }
-        format.json { render json: { question: @question }, status: :ok }
+      if html_form_request?
+        redirect_to admin_question_path(@question), notice: '質問を更新しました。'
+      else
+        render json: { question: @question }, status: :ok
       end
     else
-      respond_to do |format|
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity }
+      if html_form_request?
+        render :edit, status: :unprocessable_entity
+      else
+        render json: { errors: @question.errors.full_messages }, status: :unprocessable_entity
       end
     end
   end
@@ -98,6 +102,10 @@ class Admin::QuestionsController < ApplicationController
       format.html { redirect_to admin_questions_path, alert: '質問が見つかりませんでした。' }
       format.json { render json: { error: 'Question not found' }, status: :not_found }
     end
+  end
+
+  def html_form_request?
+    params[:format] == 'html'
   end
 
   def question_params

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -5,6 +5,7 @@ class AnswersController < ApplicationController
   # POST /questions/:question_id/answers
   def create
     @answer = @question.answers.build(answer_params)
+    apply_rating_fallback_choice!
 
     # 重複チェック
     session_id_value = answer_params[:session_id].presence || session.id.to_s
@@ -69,6 +70,19 @@ class AnswersController < ApplicationController
 
   def answer_params
     params.require(:answer).permit(:body, :session_id, :choice_id)
+  end
+
+  def apply_rating_fallback_choice!
+    return unless @question.rating?
+    return if @answer.choice_id.present?
+
+    rating_value = params.dig(:answer, :rating_value).to_s
+    return unless rating_value.match?(/\A[1-5]\z/)
+
+    choice = @question.choices.find_by(label: rating_value)
+    choice ||= @question.choices.order(:id)[rating_value.to_i - 1]
+    choice ||= @question.choices.find_or_create_by!(label: rating_value)
+    @answer.choice = choice
   end
 
   def serialize_answer(answer)

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,5 +1,5 @@
 class AnswersController < ApplicationController
-  before_action :authenticate_user!, only: [:create]
+  before_action :authenticate_user!, only: [:create], if: :html_form_request?
   before_action :set_question, only: [:create, :index]
 
   # POST /questions/:question_id/answers

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -1,23 +1,38 @@
 class AnswersController < ApplicationController
+  before_action :authenticate_user!, only: [:create]
   before_action :set_question, only: [:create, :index]
 
   # POST /questions/:question_id/answers
   def create
     @answer = @question.answers.build(answer_params)
 
-    # Check for duplicate answers
-    session_id = answer_params[:session_id]
-    if session_id.present?
-      session_hash = Digest::SHA256.hexdigest(session_id)
-      if @question.answers.exists?(session_id_hash: session_hash)
-        return render json: { errors: ['This session has already answered this question'] }, status: :unprocessable_entity
+    # 重複チェック
+    session_id_value = answer_params[:session_id].presence || session.id.to_s
+    session_hash = Digest::SHA256.hexdigest(session_id_value)
+
+    if @question.answers.exists?(session_id_hash: session_hash)
+      respond_to do |format|
+        format.html { redirect_to question_path(@question), alert: 'すでに回答済みです。' }
+        format.json { render json: { errors: ['This session has already answered this question'] }, status: :unprocessable_entity }
       end
+      return
     end
 
+    @answer.user = current_user if user_signed_in?
+
     if @answer.save
-      render json: { answer: @answer }, status: :created
+      respond_to do |format|
+        format.html { redirect_to member_dashboard_path, notice: '回答を送信しました。' }
+        format.json { render json: { answer: @answer }, status: :created }
+      end
     else
-      render json: { errors: @answer.errors.full_messages }, status: :unprocessable_entity
+      respond_to do |format|
+        format.html do
+          @already_answered = false
+          render 'questions/show', status: :unprocessable_entity
+        end
+        format.json { render json: { errors: @answer.errors.full_messages }, status: :unprocessable_entity }
+      end
     end
   end
 
@@ -46,7 +61,10 @@ class AnswersController < ApplicationController
   def set_question
     @question = Question.find(params[:question_id])
   rescue ActiveRecord::RecordNotFound
-    render json: { error: 'Question not found' }, status: :not_found
+    respond_to do |format|
+      format.html { redirect_to member_dashboard_path, alert: '質問が見つかりませんでした。' }
+      format.json { render json: { error: 'Question not found' }, status: :not_found }
+    end
   end
 
   def answer_params

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -20,7 +20,7 @@ class AnswersController < ApplicationController
       return
     end
 
-    @answer.user = current_user if user_signed_in?
+    @answer.user = current_user if html_form_request? && user_signed_in?
 
     if @answer.save
       if html_form_request?

--- a/app/controllers/answers_controller.rb
+++ b/app/controllers/answers_controller.rb
@@ -12,9 +12,10 @@ class AnswersController < ApplicationController
     session_hash = Digest::SHA256.hexdigest(session_id_value)
 
     if @question.answers.exists?(session_id_hash: session_hash)
-      respond_to do |format|
-        format.html { redirect_to question_path(@question), alert: 'すでに回答済みです。' }
-        format.json { render json: { errors: ['This session has already answered this question'] }, status: :unprocessable_entity }
+      if html_form_request?
+        redirect_to question_path(@question), alert: 'すでに回答済みです。'
+      else
+        render json: { errors: ['This session has already answered this question'] }, status: :unprocessable_entity
       end
       return
     end
@@ -22,17 +23,17 @@ class AnswersController < ApplicationController
     @answer.user = current_user if user_signed_in?
 
     if @answer.save
-      respond_to do |format|
-        format.html { redirect_to member_dashboard_path, notice: '回答を送信しました。' }
-        format.json { render json: { answer: @answer }, status: :created }
+      if html_form_request?
+        redirect_to member_dashboard_path, notice: '回答を送信しました。'
+      else
+        render json: { answer: @answer }, status: :created
       end
     else
-      respond_to do |format|
-        format.html do
-          @already_answered = false
-          render 'questions/show', status: :unprocessable_entity
-        end
-        format.json { render json: { errors: @answer.errors.full_messages }, status: :unprocessable_entity }
+      if html_form_request?
+        @already_answered = false
+        render 'questions/show', status: :unprocessable_entity
+      else
+        render json: { errors: @answer.errors.full_messages }, status: :unprocessable_entity
       end
     end
   end
@@ -62,14 +63,19 @@ class AnswersController < ApplicationController
   def set_question
     @question = Question.find(params[:question_id])
   rescue ActiveRecord::RecordNotFound
-    respond_to do |format|
-      format.html { redirect_to member_dashboard_path, alert: '質問が見つかりませんでした。' }
-      format.json { render json: { error: 'Question not found' }, status: :not_found }
+    if html_form_request?
+      redirect_to member_dashboard_path, alert: '質問が見つかりませんでした。'
+    else
+      render json: { error: 'Question not found' }, status: :not_found
     end
   end
 
   def answer_params
     params.require(:answer).permit(:body, :session_id, :choice_id)
+  end
+
+  def html_form_request?
+    params[:format] == 'html'
   end
 
   def apply_rating_fallback_choice!

--- a/app/controllers/member/answers_controller.rb
+++ b/app/controllers/member/answers_controller.rb
@@ -1,0 +1,16 @@
+module Member
+  class AnswersController < ApplicationController
+    before_action :authenticate_user!
+    before_action :check_member_role
+
+    def index
+      @answers = current_user.answers.includes(:question).order(created_at: :desc)
+    end
+
+    private
+
+    def check_member_role
+      redirect_to admin_dashboard_path if current_user.admin?
+    end
+  end
+end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,0 +1,22 @@
+class QuestionsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :check_member_role
+  before_action :set_question
+
+  def show
+    @answer = Answer.new
+    @already_answered = current_user.answers.exists?(question: @question)
+  end
+
+  private
+
+  def set_question
+    @question = Question.published.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to member_dashboard_path, alert: '質問が見つかりませんでした。'
+  end
+
+  def check_member_role
+    redirect_to admin_dashboard_path if current_user.admin?
+  end
+end

--- a/app/javascript/index.tsx
+++ b/app/javascript/index.tsx
@@ -14,5 +14,8 @@ const App: React.FC = () => {
   );
 };
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
-root.render(<App />);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  const root = ReactDOM.createRoot(rootElement);
+  root.render(<App />);
+}

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto">
-  <h1 class="text-3xl font-bold mb-6">Admin Dashboard</h1>
+  <h1 class="text-3xl font-bold mb-6">管理者ダッシュボード</h1>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
     <!-- Statistics Cards -->
@@ -10,7 +10,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
           </svg>
         </div>
-        <div class="stat-title">Total Questions</div>
+        <div class="stat-title">総質問数</div>
         <div class="stat-value"><%= @total_questions %></div>
       </div>
     </div>
@@ -22,14 +22,14 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m6 2a6 6 0 11-12 0 6 6 0 0112 0z"></path>
           </svg>
         </div>
-        <div class="stat-title">Total Answers</div>
+        <div class="stat-title">総回答数</div>
         <div class="stat-value"><%= @total_answers %></div>
       </div>
     </div>
 
     <div class="stats stats-vertical shadow">
       <div class="stat">
-        <div class="stat-title">Average Responses</div>
+        <div class="stat-title">平均回答数</div>
         <div class="stat-value"><%= @total_questions > 0 ? (@total_answers / @total_questions).round(1) : 0 %></div>
       </div>
     </div>
@@ -38,18 +38,18 @@
   <!-- Recent Questions -->
   <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title">Recent Questions</h2>
+      <h2 class="card-title">最近の質問</h2>
 
       <div class="overflow-x-auto">
         <% if @questions.any? %>
           <table class="table table-zebra w-full">
             <thead>
               <tr>
-                <th>Title</th>
-                <th>Type</th>
-                <th>Status</th>
-                <th>Answers</th>
-                <th>Actions</th>
+                <th>タイトル</th>
+                <th>タイプ</th>
+                <th>ステータス</th>
+                <th>回答数</th>
+                <th>操作</th>
               </tr>
             </thead>
             <tbody>
@@ -60,8 +60,8 @@
                   <td><span class="badge badge-<%= question.draft? ? 'warning' : question.published? ? 'info' : 'success' %>"><%= question.status %></span></td>
                   <td><%= question.answers.count %></td>
                   <td>
-                    <%= link_to 'View', admin_question_path(question), class: 'btn btn-xs btn-primary' %>
-                    <%= link_to 'Edit', edit_admin_question_path(question), class: 'btn btn-xs btn-warning' %>
+                    <%= link_to '詳細', admin_question_path(question), class: 'btn btn-xs btn-primary' %>
+                    <%= link_to '編集', edit_admin_question_path(question), class: 'btn btn-xs btn-warning' %>
                   </td>
                 </tr>
               <% end %>
@@ -72,7 +72,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
-            <span>No questions yet. <%= link_to 'Create one', new_admin_question_path, class: 'link link-primary' %></span>
+            <span>質問がまだありません。<%= link_to '作成する', new_admin_question_path, class: 'link link-primary' %></span>
           </div>
         <% end %>
       </div>
@@ -80,6 +80,6 @@
   </div>
 
   <div class="mt-6">
-    <%= link_to 'Create New Question', new_admin_question_path, class: 'btn btn-primary' %>
+    <%= link_to '新しい質問を作成', new_admin_question_path, class: 'btn btn-primary' %>
   </div>
 </div>

--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [:admin, question], local: true do |f| %>
+<%= form_with model: [:admin, question], url: question.persisted? ? admin_question_path(question, format: :html) : admin_questions_path(format: :html), local: true do |f| %>
   <% if question.errors.any? %>
     <div class="alert alert-error mb-4">
       <ul class="list-disc list-inside">

--- a/app/views/admin/questions/_form.html.erb
+++ b/app/views/admin/questions/_form.html.erb
@@ -1,0 +1,38 @@
+<%= form_with model: [:admin, question], local: true do |f| %>
+  <% if question.errors.any? %>
+    <div class="alert alert-error mb-4">
+      <ul class="list-disc list-inside">
+        <% question.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-control mb-4">
+    <%= f.label :title, 'タイトル', class: 'label label-text font-semibold' %>
+    <%= f.text_field :title, class: 'input input-bordered w-full', placeholder: '質問タイトルを入力' %>
+  </div>
+
+  <div class="form-control mb-4">
+    <%= f.label :body, '質問内容', class: 'label label-text font-semibold' %>
+    <%= f.text_area :body, rows: 6, class: 'textarea textarea-bordered w-full', placeholder: '質問内容を入力' %>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+    <div class="form-control mb-4">
+      <%= f.label :question_type, '質問タイプ', class: 'label label-text font-semibold' %>
+      <%= f.select :question_type, Question.question_types.keys.map { |k| [k, k] }, {}, class: 'select select-bordered w-full' %>
+    </div>
+
+    <div class="form-control mb-4">
+      <%= f.label :status, 'ステータス', class: 'label label-text font-semibold' %>
+      <%= f.select :status, Question.statuses.keys.map { |k| [k, k] }, {}, class: 'select select-bordered w-full' %>
+    </div>
+  </div>
+
+  <div class="card-actions justify-end mt-6">
+    <%= link_to 'キャンセル', admin_questions_path, class: 'btn btn-ghost' %>
+    <%= f.submit question.persisted? ? '更新する' : '作成する', class: 'btn btn-primary' %>
+  </div>
+<% end %>

--- a/app/views/admin/questions/edit.html.erb
+++ b/app/views/admin/questions/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="container mx-auto p-6">
+  <div class="card bg-base-100 shadow-lg">
+    <div class="card-body">
+      <h1 class="card-title text-3xl mb-4">質問編集</h1>
+      <%= render 'form', question: @question %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/questions/index.html.erb
+++ b/app/views/admin/questions/index.html.erb
@@ -1,11 +1,11 @@
 <div class="container mx-auto py-8">
-  <h1 class="text-3xl font-bold mb-6">Questions Management</h1>
+  <h1 class="text-3xl font-bold mb-6">質問管理</h1>
 
   <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="card-title">All Questions</h2>
-        <%= link_to 'New Question', new_admin_question_path, class: 'btn btn-primary' %>
+        <h2 class="card-title">すべての質問</h2>
+        <%= link_to '新しい質問', new_admin_question_path, class: 'btn btn-primary' %>
       </div>
 
       <div class="overflow-x-auto">
@@ -14,11 +14,11 @@
             <thead>
               <tr>
                 <th>ID</th>
-                <th>Title</th>
-                <th>Type</th>
-                <th>Answers</th>
-                <th>Created</th>
-                <th>Actions</th>
+                <th>タイトル</th>
+                <th>タイプ</th>
+                <th>回答数</th>
+                <th>作成日</th>
+                <th>操作</th>
               </tr>
             </thead>
             <tbody>
@@ -31,9 +31,9 @@
                   <td><%= question.created_at.strftime('%Y-%m-%d') %></td>
                   <td>
                     <div class="flex gap-2">
-                      <%= link_to 'View', admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
-                      <%= link_to 'Edit', edit_admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
-                      <%= link_to 'Delete', admin_question_path(question), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-sm btn-ghost text-error' %>
+                      <%= link_to '詳細', admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
+                      <%= link_to '編集', edit_admin_question_path(question), class: 'btn btn-sm btn-ghost' %>
+                      <%= link_to '削除', admin_question_path(question), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-sm btn-ghost text-error' %>
                     </div>
                   </td>
                 </tr>
@@ -45,7 +45,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
-            <span>No questions yet. <%= link_to 'Create one', new_admin_question_path, class: 'link link-primary' %></span>
+            <span>質問がまだありません。<%= link_to '作成する', new_admin_question_path, class: 'link link-primary' %></span>
           </div>
         <% end %>
       </div>

--- a/app/views/admin/questions/new.html.erb
+++ b/app/views/admin/questions/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container mx-auto p-6">
+  <div class="card bg-base-100 shadow-lg">
+    <div class="card-body">
+      <h1 class="card-title text-3xl mb-4">質問投稿フォーム作成</h1>
+      <%= render 'form', question: @question %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/questions/show.html.erb
+++ b/app/views/admin/questions/show.html.erb
@@ -32,9 +32,9 @@
         <% end %>
 
         <div class="card-actions justify-end mt-6">
-          <%= link_to 'Edit', edit_admin_question_path(@question), class: 'btn btn-primary' %>
-          <%= link_to 'Back', admin_questions_path, class: 'btn btn-ghost' %>
-          <%= link_to 'Delete', admin_question_path(@question), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-error' %>
+          <%= link_to '編集', edit_admin_question_path(@question), class: 'btn btn-primary' %>
+          <%= link_to '戻る', admin_questions_path, class: 'btn btn-ghost' %>
+          <%= link_to '削除', admin_question_path(@question), method: :delete, data: { confirm: '本当に削除しますか？' }, class: 'btn btn-error' %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,9 @@
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_include_tag "index", "data-turbo-track": "reload", defer: true %>
+    <% if File.exist?(Rails.root.join('app/assets/builds/index.js')) %>
+      <%= javascript_include_tag "index", "data-turbo-track": "reload", defer: true %>
+    <% end %>
   </head>
 
   <body class="flex flex-col min-h-screen bg-gray-50">

--- a/app/views/member/answers/index.html.erb
+++ b/app/views/member/answers/index.html.erb
@@ -1,0 +1,28 @@
+<div class="container mx-auto">
+  <h1 class="text-3xl font-bold mb-6">My Answers</h1>
+
+  <div class="card bg-base-100 shadow-xl">
+    <div class="card-body">
+      <% if @answers.any? %>
+        <div class="space-y-4">
+          <% @answers.each do |answer| %>
+            <div class="card bg-base-200 border border-base-300">
+              <div class="card-body">
+                <h3 class="card-title text-lg"><%= answer.question.title %></h3>
+                <p class="text-sm opacity-70"><%= answer.body %></p>
+                <p class="text-xs opacity-50"><%= answer.created_at.strftime('%Y/%m/%d %H:%M') %></p>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      <% else %>
+        <div class="alert alert-info">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          <span>まだ回答がありません。</span>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/member/dashboard/index.html.erb
+++ b/app/views/member/dashboard/index.html.erb
@@ -66,11 +66,6 @@
           <% end %>
         </div>
 
-        <% if @questions.total_pages > 1 %>
-          <div class="mt-6 flex justify-center">
-            <%= paginate @questions %>
-          </div>
-        <% end %>
       <% else %>
         <div class="alert alert-info">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">

--- a/app/views/member/dashboard/index.html.erb
+++ b/app/views/member/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto">
-  <h1 class="text-3xl font-bold mb-6">Member Dashboard</h1>
+  <h1 class="text-3xl font-bold mb-6">メンバーダッシュボード</h1>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
     <!-- Statistics Cards -->
@@ -10,7 +10,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
           </svg>
         </div>
-        <div class="stat-title">Available Questions</div>
+        <div class="stat-title">公開中の質問</div>
         <div class="stat-value"><%= @total_questions %></div>
       </div>
     </div>
@@ -22,14 +22,14 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
         </div>
-        <div class="stat-title">Questions Answered</div>
+        <div class="stat-title">回答済み質問</div>
         <div class="stat-value"><%= @answered_questions %></div>
       </div>
     </div>
 
     <div class="stats stats-vertical shadow">
       <div class="stat">
-        <div class="stat-title">Remaining</div>
+        <div class="stat-title">未回答</div>
         <div class="stat-value"><%= @total_questions - @answered_questions %></div>
       </div>
     </div>
@@ -38,7 +38,7 @@
   <!-- Available Questions -->
   <div class="card bg-base-100 shadow-xl">
     <div class="card-body">
-      <h2 class="card-title">Questions to Answer</h2>
+      <h2 class="card-title">回答可能な質問</h2>
 
       <% if @questions.any? %>
         <div class="space-y-4">
@@ -55,9 +55,9 @@
 
                   <div class="flex gap-2">
                     <% if current_user.answers.any? { |a| a.question_id == question.id } %>
-                      <span class="badge badge-success">Already Answered</span>
+                      <span class="badge badge-success">回答済み</span>
                     <% else %>
-                      <%= link_to 'Answer', member_question_path(question), class: 'btn btn-sm btn-primary' %>
+                      <%= link_to '回答する', question_path(question), class: 'btn btn-sm btn-primary' %>
                     <% end %>
                   </div>
                 </div>
@@ -76,7 +76,7 @@
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
           </svg>
-          <span>No questions available at the moment.</span>
+          <span>現在回答可能な質問はありません。</span>
         </div>
       <% end %>
     </div>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -47,14 +47,16 @@
           <% elsif @question.rating? %>
             <div class="form-control mb-6">
               <p class="label-text font-semibold mb-3">評価を選んでください</p>
-              <div class="flex gap-4 flex-wrap">
-                <% @question.choices.each do |choice| %>
-                  <label class="cursor-pointer flex flex-col items-center gap-1">
-                    <%= f.radio_button :choice_id, choice.id, class: 'radio radio-primary' %>
-                    <span class="label-text"><%= choice.label %></span>
-                  </label>
-                <% end %>
+              <div class="bg-base-200 rounded-xl p-4 border border-base-300 inline-block">
+                <div class="rating rating-lg gap-1">
+                  <input type="radio" name="answer[rating_value]" value="" class="rating-hidden" />
+                  <% (1..5).each do |value| %>
+                    <%= radio_button_tag 'answer[rating_value]', value, false, class: 'mask mask-star-2 bg-warning', aria: { label: "#{value} 点" } %>
+                  <% end %>
+                </div>
               </div>
+              <p class="text-xs text-base-content/70 mt-2">1（低い）〜5（高い）で評価してください</p>
+              <%= f.hidden_field :choice_id, value: '' %>
             </div>
           <% end %>
 

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -16,7 +16,7 @@
           <span>この質問にはすでに回答済みです。</span>
         </div>
       <% else %>
-        <%= form_with model: [@question, @answer], url: question_answers_path(@question), local: true do |f| %>
+        <%= form_with model: [@question, @answer], url: question_answers_path(@question, format: :html), local: true do |f| %>
           <% if @answer.errors.any? %>
             <div class="alert alert-error mb-4">
               <ul class="list-disc list-inside">

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,0 +1,70 @@
+<div class="container mx-auto py-8 max-w-2xl">
+  <div class="mb-4">
+    <%= link_to '← ダッシュボードに戻る', member_dashboard_path, class: 'link link-primary text-sm' %>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl">
+    <div class="card-body">
+      <h1 class="card-title text-2xl mb-2"><%= @question.title %></h1>
+      <p class="text-base-content/70 mb-6 whitespace-pre-wrap"><%= @question.body %></p>
+
+      <% if @already_answered %>
+        <div class="alert alert-success">
+          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>この質問にはすでに回答済みです。</span>
+        </div>
+      <% else %>
+        <%= form_with model: [@question, @answer], url: question_answers_path(@question), local: true do |f| %>
+          <% if @answer.errors.any? %>
+            <div class="alert alert-error mb-4">
+              <ul class="list-disc list-inside">
+                <% @answer.errors.full_messages.each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <% if @question.text? %>
+            <div class="form-control mb-6">
+              <%= f.label :body, '回答', class: 'label label-text font-semibold' %>
+              <%= f.text_area :body, rows: 5, placeholder: 'ここに回答を入力してください', class: 'textarea textarea-bordered w-full' %>
+            </div>
+
+          <% elsif @question.choice? %>
+            <div class="form-control mb-6">
+              <p class="label-text font-semibold mb-3">選択肢を選んでください</p>
+              <% @question.choices.each do |choice| %>
+                <label class="label cursor-pointer justify-start gap-4 py-2">
+                  <%= f.radio_button :choice_id, choice.id, class: 'radio radio-primary' %>
+                  <span class="label-text text-base"><%= choice.label %></span>
+                </label>
+              <% end %>
+            </div>
+
+          <% elsif @question.rating? %>
+            <div class="form-control mb-6">
+              <p class="label-text font-semibold mb-3">評価を選んでください</p>
+              <div class="flex gap-4 flex-wrap">
+                <% @question.choices.each do |choice| %>
+                  <label class="cursor-pointer flex flex-col items-center gap-1">
+                    <%= f.radio_button :choice_id, choice.id, class: 'radio radio-primary' %>
+                    <span class="label-text"><%= choice.label %></span>
+                  </label>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+
+          <%= f.hidden_field :session_id, value: session.id.to_s %>
+
+          <div class="card-actions justify-end mt-4">
+            <%= f.submit '回答を送信', class: 'btn btn-primary' %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_admin_navbar.html.erb
+++ b/app/views/shared/_admin_navbar.html.erb
@@ -15,7 +15,6 @@
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><a href="<%= admin_dashboard_path %>" class="text-black">質問管理</a></li>
         <li><a href="<%= new_admin_question_path %>" class="text-black">質問投稿フォーム作成</a></li>
-        <li><hr class="my-2"></li>
         <li>
           <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
         </li>

--- a/app/views/shared/_admin_navbar.html.erb
+++ b/app/views/shared/_admin_navbar.html.erb
@@ -11,12 +11,12 @@
     </div>
 
     <div class="dropdown dropdown-end">
-      <button tabindex="0" class="btn btn-ghost">Menu</button>
+      <button tabindex="0" class="btn btn-ghost">メニュー</button>
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><a href="<%= admin_dashboard_path %>">Manage Questions</a></li>
+        <li><a href="<%= admin_dashboard_path %>" class="text-black">質問管理</a></li>
         <li><hr class="my-2"></li>
         <li>
-          <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
+          <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
         </li>
       </ul>
     </div>

--- a/app/views/shared/_admin_navbar.html.erb
+++ b/app/views/shared/_admin_navbar.html.erb
@@ -14,6 +14,7 @@
       <button tabindex="0" class="btn btn-ghost">メニュー</button>
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><a href="<%= admin_dashboard_path %>" class="text-black">質問管理</a></li>
+        <li><a href="<%= new_admin_question_path %>" class="text-black">質問投稿フォーム作成</a></li>
         <li><hr class="my-2"></li>
         <li>
           <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -3,7 +3,7 @@
     <p>
       Copyright © 2026 <strong>Honest Voice</strong> - All rights reserved.
       <br />
-      <small>Complete Anonymous Feedback Collection Platform</small>
+      <small>完全匿名フィードバック収集プラットフォーム</small>
     </p>
   </aside>
 </footer>

--- a/app/views/shared/_member_navbar.html.erb
+++ b/app/views/shared/_member_navbar.html.erb
@@ -15,7 +15,6 @@
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
         <li><a href="<%= member_dashboard_path %>" class="text-black">質問に回答する</a></li>
         <li><a href="<%= member_answers_path %>" class="text-black">自分の回答</a></li>
-        <li><hr class="my-2"></li>
         <li>
           <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
         </li>

--- a/app/views/shared/_member_navbar.html.erb
+++ b/app/views/shared/_member_navbar.html.erb
@@ -11,13 +11,13 @@
     </div>
 
     <div class="dropdown dropdown-end">
-      <button tabindex="0" class="btn btn-ghost">Menu</button>
+      <button tabindex="0" class="btn btn-ghost">メニュー</button>
       <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
-        <li><a href="<%= member_dashboard_path %>">Answer Questions</a></li>
-        <li><a href="<%= member_answers_path %>">My Answers</a></li>
+        <li><a href="<%= member_dashboard_path %>" class="text-black">質問に回答する</a></li>
+        <li><a href="<%= member_answers_path %>" class="text-black">自分の回答</a></li>
         <li><hr class="my-2"></li>
         <li>
-          <%= button_to 'Sign Out', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
+          <%= button_to 'サインアウト', destroy_user_session_path, method: :delete, class: 'btn btn-ghost btn-sm text-error' %>
         </li>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
   # Member namespace
   namespace :member, path: 'member' do
     get 'dashboard', to: 'dashboard#index', as: :dashboard
+    resources :answers, only: [:index]
   end
 
   # Health check and PWA

--- a/spec/requests/defects_fix_spec.rb
+++ b/spec/requests/defects_fix_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe 'Defects Fix Regression', type: :request do
 
     it 'rating_value を送信すると回答と選択肢が保存される' do
       expect do
-        post "/questions/#{rating_question.id}/answers", params: {
+        post "/questions/#{rating_question.id}/answers.html", params: {
           answer: {
             rating_value: '4',
             session_id: 'rating-flow-session-001'
           }
-        }, format: :html
+        }
       end.to change(Answer, :count).by(1)
 
       expect(response).to redirect_to(member_dashboard_path)

--- a/spec/requests/defects_fix_spec.rb
+++ b/spec/requests/defects_fix_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Defects Fix Regression', type: :request do
             rating_value: '4',
             session_id: 'rating-flow-session-001'
           }
-        }
+        }, format: :html
       end.to change(Answer, :count).by(1)
 
       expect(response).to redirect_to(member_dashboard_path)

--- a/spec/requests/defects_fix_spec.rb
+++ b/spec/requests/defects_fix_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe 'Defects Fix Regression', type: :request do
+  let(:admin_user) { create(:user, :admin) }
+  let(:member_user) { create(:user, :member) }
+
+  describe '管理者質問画面テンプレート' do
+    before { sign_in admin_user }
+
+    let(:question) { create(:question, :published, user: admin_user) }
+
+    it 'GET /admin/questions/new が表示できる' do
+      get '/admin/questions/new'
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'GET /admin/questions/:id/edit が表示できる' do
+      get "/admin/questions/#{question.id}/edit"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'メンバー評価回答フロー' do
+    before { sign_in member_user }
+
+    let(:rating_question) { create(:question, :published, :rating_type) }
+
+    it '評価質問画面に星評価入力が表示される' do
+      get "/questions/#{rating_question.id}"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('rating rating-lg')
+      expect(response.body).to include('answer[rating_value]')
+    end
+
+    it 'rating_value を送信すると回答と選択肢が保存される' do
+      expect do
+        post "/questions/#{rating_question.id}/answers", params: {
+          answer: {
+            rating_value: '4',
+            session_id: 'rating-flow-session-001'
+          }
+        }
+      end.to change(Answer, :count).by(1)
+
+      expect(response).to redirect_to(member_dashboard_path)
+      answer = Answer.last
+      expect(answer.choice).to be_present
+      expect(answer.choice.label).to eq('4')
+      expect(answer.user).to eq(member_user)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Issue #25 に対応し、fix/defects ブランチの不備修正を取り込みます。

## 変更内容
- メンバー回答導線（質問詳細表示・回答送信）を整備
- 管理者質問の new/edit テンプレート不足を解消
- 管理画面の質問作成/更新処理を HTML/JSON 両対応に改善
- 評価質問UIを DaisyUI の星評価に変更
- rating_value から choice を解決する保存処理を追加
- メンバーダッシュボードのページネーション未導入時エラーを解消
- ナビゲーション文言と導線を調整

## テスト
- spec/requests/defects_fix_spec.rb を追加
  - 管理者質問画面の new/edit 表示
  - 評価質問の星UI表示
  - 評価回答の保存（rating_value から choice への変換）

## 関連Issue
Closes #25