### PR TITLE
feat(issue-28): 招待フロー（InviteToken）とメンバー管理のPhase2実装

### DIFF
--- a/app/controllers/admin/company_members_controller.rb
+++ b/app/controllers/admin/company_members_controller.rb
@@ -1,0 +1,83 @@
+class Admin::CompanyMembersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_company
+  before_action :set_company_member, only: [:update, :destroy]
+
+  def index
+    unless owner_or_manager?
+      render json: { error: 'この操作は許可されていません。' }, status: :forbidden
+      return
+    end
+
+    members = @company.company_members.includes(:user).order(created_at: :asc)
+
+    render json: {
+      members: members.map { |member| serialize_member(member) }
+    }, status: :ok
+  end
+
+  def update
+    unless owner?
+      render json: { error: 'ownerのみロールを更新できます。' }, status: :forbidden
+      return
+    end
+
+    if @company_member.update(company_member_params)
+      render json: { member: serialize_member(@company_member) }, status: :ok
+    else
+      render json: { errors: @company_member.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    unless owner?
+      render json: { error: 'ownerのみメンバーを除外できます。' }, status: :forbidden
+      return
+    end
+
+    if @company_member.owner?
+      render json: { error: 'ownerは除外できません。' }, status: :unprocessable_entity
+      return
+    end
+
+    @company_member.destroy!
+    render json: { message: 'メンバーを除外しました。' }, status: :ok
+  end
+
+  private
+
+  def set_company
+    @company = Company.find(params[:company_id])
+  end
+
+  def set_company_member
+    @company_member = @company.company_members.find(params[:id])
+  end
+
+  def company_member_params
+    params.require(:company_member).permit(:role)
+  end
+
+  def owner?
+    @company.owner_id == current_user.id
+  end
+
+  def owner_or_manager?
+    return true if owner?
+
+    company_member = @company.company_members.find_by(user_id: current_user.id)
+    company_member&.manager?
+  end
+
+  def serialize_member(member)
+    {
+      id: member.id,
+      role: member.role,
+      user: {
+        id: member.user.id,
+        email: member.user.email,
+        name: member.user.name
+      }
+    }
+  end
+end

--- a/app/controllers/admin/invite_tokens_controller.rb
+++ b/app/controllers/admin/invite_tokens_controller.rb
@@ -1,0 +1,75 @@
+class Admin::InviteTokensController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_company
+  before_action :set_invite_token, only: [:deactivate, :destroy]
+  before_action :authorize_manage_tokens!
+
+  def index
+    invite_tokens = @company.invite_tokens.order(created_at: :desc)
+
+    render json: {
+      invite_tokens: invite_tokens.map { |token| serialize_token(token) }
+    }, status: :ok
+  end
+
+  def create
+    invite_token = @company.invite_tokens.new(invite_token_params)
+    invite_token.creator = current_user
+
+    if invite_token.save
+      render json: { invite_token: serialize_token(invite_token) }, status: :created
+    else
+      render json: { errors: invite_token.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def deactivate
+    if @invite_token.update(active: false, status: :used)
+      render json: { invite_token: serialize_token(@invite_token) }, status: :ok
+    else
+      render json: { errors: @invite_token.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @invite_token.destroy!
+    render json: { message: '招待トークンを削除しました。' }, status: :ok
+  end
+
+  private
+
+  def set_company
+    @company = Company.find(params[:company_id])
+  end
+
+  def set_invite_token
+    @invite_token = @company.invite_tokens.find(params[:id])
+  end
+
+  def authorize_manage_tokens!
+    return if current_user.admin?
+
+    member = @company.company_members.find_by(user_id: current_user.id)
+    return if member&.manager?
+
+    render json: { error: 'この操作は許可されていません。' }, status: :forbidden
+  end
+
+  def invite_token_params
+    params.fetch(:invite_token, {}).permit(:expires_at, :max_uses)
+  end
+
+  def serialize_token(token)
+    {
+      id: token.id,
+      token: token.token,
+      invite_url: join_invite_url(token: token.token),
+      status: token.status,
+      active: token.active,
+      max_uses: token.max_uses,
+      use_count: token.use_count,
+      expires_at: token.expires_at,
+      created_at: token.created_at
+    }
+  end
+end

--- a/app/controllers/invite_tokens_controller.rb
+++ b/app/controllers/invite_tokens_controller.rb
@@ -1,0 +1,32 @@
+class InviteTokensController < ApplicationController
+  before_action :set_invite_token
+
+  def join
+    unless user_signed_in?
+      session[:pending_invite_token] = @invite_token.token
+      redirect_to new_user_session_path, alert: 'ログイン後に招待参加を継続します。'
+      return
+    end
+
+    unless @invite_token.valid_for_use?
+      redirect_to root_path, alert: 'この招待URLは無効または期限切れです。'
+      return
+    end
+
+    if @invite_token.company.company_members.exists?(user_id: current_user.id)
+      redirect_to '/member/dashboard', notice: 'すでに参加済みです。'
+      return
+    end
+
+    @invite_token.company.add_member(current_user, :member)
+    @invite_token.mark_as_used(current_user)
+
+    redirect_to '/member/dashboard', notice: '会社に参加しました。'
+  end
+
+  private
+
+  def set_invite_token
+    @invite_token = InviteToken.find_by!(token: params[:token])
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,6 +20,13 @@ class Users::SessionsController < Devise::SessionsController
 
   # protected
 
+  def after_sign_in_path_for(resource)
+    pending_token = session.delete(:pending_invite_token)
+    return "/invite/#{pending_token}" if pending_token.present?
+
+    super(resource)
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])

--- a/app/javascript/components/InviteTokenManager.jsx
+++ b/app/javascript/components/InviteTokenManager.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from 'react';
+
+export default function InviteTokenManager({ companyId }) {
+  const [tokens, setTokens] = useState([]);
+  const [maxUses, setMaxUses] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  const fetchTokens = async () => {
+    const response = await fetch(`/admin/companies/${companyId}/invite_tokens`);
+    if (!response.ok) return;
+
+    const data = await response.json();
+    setTokens(data.invite_tokens || []);
+  };
+
+  const createToken = async () => {
+    setLoading(true);
+    const response = await fetch(`/admin/companies/${companyId}/invite_tokens`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
+      },
+      body: JSON.stringify({ invite_token: { max_uses: Number(maxUses) } })
+    });
+
+    setLoading(false);
+    if (!response.ok) return;
+    await fetchTokens();
+  };
+
+  const deactivateToken = async (id) => {
+    const response = await fetch(`/admin/companies/${companyId}/invite_tokens/${id}/deactivate`, {
+      method: 'PATCH',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
+      }
+    });
+
+    if (!response.ok) return;
+    await fetchTokens();
+  };
+
+  useEffect(() => {
+    fetchTokens();
+  }, []);
+
+  return (
+    <div className="card bg-base-100 shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title">招待URL管理</h2>
+
+        <div className="flex items-center gap-3">
+          <label className="label">最大利用回数</label>
+          <input
+            className="input input-bordered w-32"
+            type="number"
+            min={1}
+            value={maxUses}
+            onChange={(e) => setMaxUses(e.target.value)}
+          />
+          <button className={`btn btn-primary ${loading ? 'btn-disabled' : ''}`} onClick={createToken}>
+            招待URLを発行
+          </button>
+        </div>
+
+        <div className="overflow-x-auto mt-4">
+          <table className="table table-zebra">
+            <thead>
+              <tr>
+                <th>URL</th>
+                <th>状態</th>
+                <th>利用回数</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tokens.map((token) => (
+                <tr key={token.id}>
+                  <td className="max-w-xl truncate">{token.invite_url}</td>
+                  <td>{token.active ? '有効' : '無効'}</td>
+                  <td>{token.use_count} / {token.max_uses}</td>
+                  <td>
+                    {token.active && (
+                      <button className="btn btn-sm btn-warning" onClick={() => deactivateToken(token.id)}>
+                        無効化
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/components/MemberRoleManager.jsx
+++ b/app/javascript/components/MemberRoleManager.jsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+
+const ROLE_OPTIONS = ['owner', 'manager', 'member', 'viewer'];
+
+export default function MemberRoleManager({ companyId }) {
+  const [members, setMembers] = useState([]);
+
+  const fetchMembers = async () => {
+    const response = await fetch(`/admin/companies/${companyId}/company_members`);
+    if (!response.ok) return;
+
+    const data = await response.json();
+    setMembers(data.members || []);
+  };
+
+  const updateRole = async (memberId, role) => {
+    const response = await fetch(`/admin/companies/${companyId}/company_members/${memberId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
+      },
+      body: JSON.stringify({ company_member: { role } })
+    });
+
+    if (!response.ok) return;
+    await fetchMembers();
+  };
+
+  const removeMember = async (memberId) => {
+    const response = await fetch(`/admin/companies/${companyId}/company_members/${memberId}`, {
+      method: 'DELETE',
+      headers: {
+        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content || ''
+      }
+    });
+
+    if (!response.ok) return;
+    await fetchMembers();
+  };
+
+  useEffect(() => {
+    fetchMembers();
+  }, []);
+
+  return (
+    <div className="card bg-base-100 shadow-xl mt-6">
+      <div className="card-body">
+        <h2 className="card-title">メンバー権限管理</h2>
+
+        <div className="overflow-x-auto">
+          <table className="table table-zebra">
+            <thead>
+              <tr>
+                <th>名前</th>
+                <th>メール</th>
+                <th>ロール</th>
+                <th>操作</th>
+              </tr>
+            </thead>
+            <tbody>
+              {members.map((member) => (
+                <tr key={member.id}>
+                  <td>{member.user?.name || '(未設定)'}</td>
+                  <td>{member.user?.email}</td>
+                  <td>
+                    <select
+                      className="select select-bordered select-sm"
+                      value={member.role}
+                      onChange={(e) => updateRole(member.id, e.target.value)}
+                    >
+                      {ROLE_OPTIONS.map((role) => (
+                        <option key={role} value={role}>{role}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <button className="btn btn-sm btn-error" onClick={() => removeMember(member.id)}>
+                      除外
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/models/invite_token.rb
+++ b/app/models/invite_token.rb
@@ -7,6 +7,8 @@ class InviteToken < ApplicationRecord
 
   validates :company_id, presence: true
   validates :token, presence: true, uniqueness: true
+  validates :max_uses, numericality: { only_integer: true, greater_than: 0 }, allow_nil: true
+  validates :use_count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
   enum :status, { active: 0, used: 1, expired: 2 }
 
@@ -17,15 +19,27 @@ class InviteToken < ApplicationRecord
   scope :not_expired, -> { where('expires_at > ?', Time.current) }
 
   def expired?
-    expires_at && expires_at < Time.current
+    return false unless expires_at
+
+    expires_at < Time.current
   end
 
   def valid_for_use?
-    active? && !expired?
+    active? && status == 'active' && !expired? && has_remaining_uses?
   end
 
   def mark_as_used(user = nil)
-    update(status: :used, used_by: user, used_at: Time.current)
+    self.use_count ||= 0
+    self.use_count += 1
+    self.used_by = user
+    self.used_at = Time.current
+
+    if max_uses.present? && use_count >= max_uses
+      self.active = false
+      self.status = :used
+    end
+
+    save!
   end
 
   private
@@ -36,5 +50,11 @@ class InviteToken < ApplicationRecord
 
   def set_expires_at
     self.expires_at ||= 7.days.from_now
+  end
+
+  def has_remaining_uses?
+    return true if max_uses.blank?
+
+    use_count.to_i < max_uses
   end
 end

--- a/app/models/invite_token.rb
+++ b/app/models/invite_token.rb
@@ -25,7 +25,7 @@ class InviteToken < ApplicationRecord
   end
 
   def valid_for_use?
-    active? && status == 'active' && !expired? && has_remaining_uses?
+    self[:active] && status == 'active' && !expired? && has_remaining_uses?
   end
 
   def mark_as_used(user = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
     resources :answers, only: [:create, :index]
   end
 
+  get 'invite/:token', to: 'invite_tokens#join', as: :join_invite
+
   # Validation
   post 'validate-answer', to: 'validation#validate_answer'
 
@@ -20,6 +22,17 @@ Rails.application.routes.draw do
     get 'dashboard', to: 'dashboard#index', as: :dashboard
     get 'form-template', to: 'forms#template', as: :form_template
     post 'validate-question', to: 'forms#validate_question'
+
+    resources :companies, only: [] do
+      resources :invite_tokens, only: [:index, :create, :destroy] do
+        member do
+          patch :deactivate
+        end
+      end
+
+      resources :company_members, only: [:index, :update, :destroy]
+    end
+
     resources :questions do
       resources :choices, only: [:create, :update, :destroy]
       get 'statistics', to: 'statistics#show', as: :statistics

--- a/db/migrate/20260504000014_add_usage_fields_to_invite_tokens.rb
+++ b/db/migrate/20260504000014_add_usage_fields_to_invite_tokens.rb
@@ -1,0 +1,7 @@
+class AddUsageFieldsToInviteTokens < ActiveRecord::Migration[8.1]
+  def change
+    add_column :invite_tokens, :active, :boolean, default: true, null: false
+    add_column :invite_tokens, :max_uses, :integer, default: 1, null: false
+    add_column :invite_tokens, :use_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_000013) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_000014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -99,13 +99,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_000013) do
   end
 
   create_table "invite_tokens", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
     t.bigint "company_id", null: false
     t.datetime "created_at", null: false
     t.bigint "creator_id"
     t.datetime "expires_at"
+    t.integer "max_uses", default: 1, null: false
     t.integer "status", default: 0
     t.string "token", null: false
     t.datetime "updated_at", null: false
+    t.integer "use_count", default: 0, null: false
     t.datetime "used_at"
     t.integer "used_by_id"
     t.index ["company_id", "status"], name: "index_invite_tokens_on_company_id_and_status"

--- a/spec/factories/invite_tokens.rb
+++ b/spec/factories/invite_tokens.rb
@@ -5,6 +5,9 @@ FactoryBot.define do
     company
     creator { association :user }
     status { :active }
+    active { true }
+    max_uses { 1 }
+    use_count { 0 }
     expires_at { 7.days.from_now }
     used_by { nil }
     used_at { nil }

--- a/spec/models/invite_token_spec.rb
+++ b/spec/models/invite_token_spec.rb
@@ -89,11 +89,36 @@ RSpec.describe InviteToken, type: :model do
         invite_token.update(status: :active, expires_at: 1.day.ago)
         expect(invite_token.valid_for_use?).to be false
       end
+
+      it 'returns false when active is false' do
+        invite_token.update(status: :active, expires_at: 1.day.from_now, active: false)
+        expect(invite_token.valid_for_use?).to be false
+      end
+
+      it 'returns false when use_count reaches max_uses' do
+        invite_token.update(status: :active, expires_at: 1.day.from_now, max_uses: 3, use_count: 3)
+        expect(invite_token.valid_for_use?).to be false
+      end
     end
 
     describe '#mark_as_used' do
       it 'updates status to used' do
         invite_token.mark_as_used
+        expect(invite_token.status).to eq('used')
+      end
+
+      it 'increments use_count' do
+        invite_token.update(use_count: 0, max_uses: 5)
+        invite_token.mark_as_used
+        expect(invite_token.reload.use_count).to eq(1)
+      end
+
+      it 'deactivates token when use_count reaches max_uses' do
+        invite_token.update(use_count: 0, max_uses: 1, active: true)
+        invite_token.mark_as_used
+        invite_token.reload
+
+        expect(invite_token.active).to be false
         expect(invite_token.status).to eq('used')
       end
     end

--- a/spec/requests/company_members_spec.rb
+++ b/spec/requests/company_members_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe 'CompanyMembers', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:owner) { create(:user, :admin) }
+  let(:manager_user) { create(:user, :member) }
+  let(:target_user) { create(:user, :member) }
+  let(:company) { create(:company, owner_id: owner.id) }
+  let!(:manager_member) { create(:company_member, company: company, user: manager_user, role: :manager) }
+  let!(:target_member) { create(:company_member, company: company, user: target_user, role: :member) }
+
+  describe 'GET /admin/companies/:company_id/company_members' do
+    context 'owner ユーザー' do
+      before { sign_in owner }
+
+      it 'メンバー一覧を取得できる' do
+        get "/admin/companies/#{company.id}/company_members"
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+        expect(json['members']).to be_an(Array)
+        expect(json['members'].size).to be >= 2
+      end
+    end
+  end
+
+  describe 'PATCH /admin/companies/:company_id/company_members/:id' do
+    context 'owner ユーザー' do
+      before { sign_in owner }
+
+      it 'ロール変更ができる' do
+        patch "/admin/companies/#{company.id}/company_members/#{target_member.id}", params: {
+          company_member: { role: :viewer }
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(target_member.reload.role).to eq('viewer')
+      end
+    end
+
+    context 'owner 以外のユーザー' do
+      before { sign_in manager_user }
+
+      it 'ロール変更できない' do
+        patch "/admin/companies/#{company.id}/company_members/#{target_member.id}", params: {
+          company_member: { role: :viewer }
+        }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(target_member.reload.role).to eq('member')
+      end
+    end
+  end
+
+  describe 'DELETE /admin/companies/:company_id/company_members/:id' do
+    context 'owner ユーザー' do
+      before { sign_in owner }
+
+      it 'メンバー除外ができる' do
+        expect do
+          delete "/admin/companies/#{company.id}/company_members/#{target_member.id}"
+        end.to change(CompanyMember, :count).by(-1)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'owner 以外のユーザー' do
+      before { sign_in manager_user }
+
+      it 'メンバー除外できない' do
+        expect do
+          delete "/admin/companies/#{company.id}/company_members/#{target_member.id}"
+        end.not_to change(CompanyMember, :count)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/invite_tokens_spec.rb
+++ b/spec/requests/invite_tokens_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe 'InviteTokens', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:owner) { create(:user, :admin) }
+  let(:member_user) { create(:user, :member) }
+  let(:other_user) { create(:user, :member) }
+  let(:company) { create(:company, owner_id: owner.id) }
+
+  describe 'POST /admin/companies/:company_id/invite_tokens' do
+    context 'admin 以上のユーザー' do
+      before { sign_in owner }
+
+      it '招待URL発行ができる' do
+        expect do
+          post "/admin/companies/#{company.id}/invite_tokens", params: { invite_token: { max_uses: 3 } }
+        end.to change(InviteToken, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        json = JSON.parse(response.body)
+        expect(json['invite_token']['token']).to be_present
+      end
+    end
+
+    context '未認証ユーザー' do
+      it 'ログインページへリダイレクトされる' do
+        post "/admin/companies/#{company.id}/invite_tokens"
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'GET /invite/:token' do
+    let(:invite_token) { create(:invite_token, company: company, max_uses: 3, use_count: 0, active: true) }
+
+    context '未ログインユーザー' do
+      it 'ログイン画面へ遷移し、ログイン後参加を継続できる' do
+        get "/invite/#{invite_token.token}"
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+
+      it 'ログイン後に招待URLへ復帰する' do
+        get "/invite/#{invite_token.token}"
+
+        post user_session_path, params: {
+          user: {
+            email: other_user.email,
+            password: 'password123'
+          }
+        }
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to("/invite/#{invite_token.token}")
+      end
+    end
+
+    context '既存メンバー' do
+      before do
+        create(:company_member, company: company, user: member_user, role: :member)
+        sign_in member_user
+      end
+
+      it '再参加せず質問一覧へ遷移する' do
+        expect do
+          get "/invite/#{invite_token.token}"
+        end.not_to change(CompanyMember, :count)
+
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to('/member/dashboard')
+      end
+    end
+
+    context '未参加のログインユーザー' do
+      before { sign_in other_user }
+
+      it '会社へ参加し、use_countを更新する' do
+        expect do
+          get "/invite/#{invite_token.token}"
+        end.to change(CompanyMember, :count).by(1)
+
+        invite_token.reload
+        expect(invite_token.use_count).to eq(1)
+        expect(response).to have_http_status(:found)
+        expect(response).to redirect_to('/member/dashboard')
+      end
+    end
+  end
+end

--- a/spec/requests/invite_tokens_spec.rb
+++ b/spec/requests/invite_tokens_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'InviteTokens', type: :request do
           }
         }
 
-        expect(response).to have_http_status(:found)
+        expect(response).to have_http_status(:see_other)
         expect(response).to redirect_to("/invite/#{invite_token.token}")
       end
     end
@@ -78,6 +78,8 @@ RSpec.describe 'InviteTokens', type: :request do
       before { sign_in other_user }
 
       it '会社へ参加し、use_countを更新する' do
+        invite_token
+
         expect do
           get "/invite/#{invite_token.token}"
         end.to change(CompanyMember, :count).by(1)


### PR DESCRIPTION
## 概要\nIssue #28 に沿って、招待フロー（InviteToken）と会社メンバー管理（CompanyMember）を実装します。\n\n## 実装予定\n- InviteTokensController: create / join / deactivate / destroy\n- CompanyMembersController: index / update / destroy\n- Pundit ポリシーによる owner/admin/member 権限制御\n- 画面: メンバー一覧、ロール変更、招待URL発行/一覧/無効化\n- React: InviteTokenManager.jsx, MemberRoleManager.jsx\n\n## 進め方\n1. テストコード追加\n2. 実装コード追加\n3. 受け入れ条件の確認\n\nRefs #28