### PR TITLE
feat(issue-29): Phase3 Questions/Answers/Stats のController・View・React実装

### DIFF
--- a/app/controllers/admin/admin_replies_controller.rb
+++ b/app/controllers/admin/admin_replies_controller.rb
@@ -1,0 +1,77 @@
+module Admin
+  class AdminRepliesController < ApplicationController
+    before_action :authenticate_user!
+    before_action :authorize_admin!
+    before_action :set_question
+    before_action :set_answer
+    before_action :set_admin_reply, only: [:destroy]
+
+    # GET /admin/questions/:question_id/answers/:answer_id/admin_replies
+    def index
+      @admin_replies = @answer.admin_replies.includes(:user).order(created_at: :desc)
+      render json: { admin_replies: serialize_replies(@admin_replies) }
+    end
+
+    # POST /admin/questions/:question_id/answers/:answer_id/admin_replies
+    def create
+      @admin_reply = @answer.admin_replies.build(admin_reply_params)
+      @admin_reply.user = current_user
+
+      if @admin_reply.save
+        render json: { admin_reply: serialize_reply(@admin_reply) }, status: :created
+      else
+        render json: { errors: @admin_reply.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    # DELETE /admin/questions/:question_id/answers/:answer_id/admin_replies/:id
+    def destroy
+      @admin_reply.destroy
+      head :no_content
+    end
+
+    private
+
+    def set_question
+      @question = Question.find(params[:question_id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'Question not found' }, status: :not_found
+    end
+
+    def set_answer
+      @answer = @question.answers.find(params[:answer_id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'Answer not found' }, status: :not_found
+    end
+
+    def set_admin_reply
+      @admin_reply = @answer.admin_replies.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: 'AdminReply not found' }, status: :not_found
+    end
+
+    def admin_reply_params
+      params.require(:admin_reply).permit(:reply_text, :status)
+    end
+
+    def authorize_admin!
+      render json: { error: 'Forbidden' }, status: :forbidden unless current_user.admin?
+    end
+
+    def serialize_replies(replies)
+      replies.map { |r| serialize_reply(r) }
+    end
+
+    def serialize_reply(reply)
+      {
+        id: reply.id,
+        reply_text: reply.reply_text,
+        status: reply.status,
+        user_id: reply.user_id,
+        answer_id: reply.answer_id,
+        created_at: reply.created_at,
+        updated_at: reply.updated_at
+      }
+    end
+  end
+end

--- a/app/controllers/member/questions_controller.rb
+++ b/app/controllers/member/questions_controller.rb
@@ -1,0 +1,74 @@
+module Member
+  class QuestionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :check_member_role
+    before_action :set_company
+    before_action :set_question, only: [:show]
+
+    # GET /member/questions
+    def index
+      tab = params[:tab].presence || 'unanswered'
+      questions = fetch_questions_by_tab(tab)
+
+      respond_to do |format|
+        format.html { @questions = questions; @tab = tab }
+        format.json do
+          render json: {
+            questions: questions.map { |q| serialize_question(q) },
+            tab: tab
+          }
+        end
+      end
+    end
+
+    # GET /member/questions/:id
+    def show
+      @answer = Answer.new
+      @already_answered = @question.answers.exists?(user_id: current_user.id)
+    end
+
+    private
+
+    def set_company
+      @company = current_user.companies.first || current_user.owned_companies.first
+    end
+
+    def set_question
+      @question = Question.published.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      redirect_to member_dashboard_path, alert: '質問が見つかりませんでした。'
+    end
+
+    def fetch_questions_by_tab(tab)
+      base = @company ? Question.where(company: @company) : Question.none
+
+      case tab
+      when 'unanswered'
+        answered_ids = current_user.answers.select(:question_id)
+        base.published.where.not(id: answered_ids)
+      when 'answered'
+        answered_ids = current_user.answers.select(:question_id)
+        base.published.where(id: answered_ids)
+      when 'closed'
+        base.closed
+      else
+        base.published
+      end.order(created_at: :desc)
+    end
+
+    def serialize_question(question)
+      {
+        id: question.id,
+        title: question.title,
+        body: question.body,
+        question_type: question.question_type,
+        status: question.status,
+        created_at: question.created_at
+      }
+    end
+
+    def check_member_role
+      redirect_to admin_dashboard_path if current_user.admin?
+    end
+  end
+end

--- a/app/javascript/components/AnswerForm.jsx
+++ b/app/javascript/components/AnswerForm.jsx
@@ -1,0 +1,161 @@
+import React, { useState } from 'react';
+
+/**
+ * AnswerForm - 回答フォームコンポーネント
+ * Member が質問に対して匿名で回答するための React フォーム
+ * question_type に応じて入力形式が切り替わる
+ */
+const AnswerForm = ({ question, sessionId, onSuccess }) => {
+  const [selectedChoiceId, setSelectedChoiceId] = useState('');
+  const [ratingValue, setRatingValue] = useState(0);
+  const [bodyText, setBodyText] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState([]);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrors([]);
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    const payload = {
+      answer: {
+        session_id: sessionId,
+        body: question.question_type === 'text' ? bodyText : null,
+        choice_id: question.question_type === 'choice' ? selectedChoiceId : null,
+        rating_value: question.question_type === 'rating' ? ratingValue : null,
+      },
+    };
+
+    try {
+      const res = await fetch(`/questions/${question.id}/answers`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setErrors(data.errors || ['回答の送信に失敗しました。']);
+      } else {
+        setSubmitted(true);
+        onSuccess?.(data.answer);
+      }
+    } catch {
+      setErrors(['通信エラーが発生しました。']);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="alert alert-success">
+        <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span>回答を送信しました。ありがとうございました。</span>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {errors.length > 0 && (
+        <div className="alert alert-error">
+          <ul className="list-disc list-inside">
+            {errors.map((err, i) => (
+              <li key={i}>{err}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* テキスト型 */}
+      {question.question_type === 'text' && (
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text font-semibold">回答</span>
+            <span className="label-text-alt text-base-content/50">匿名</span>
+          </label>
+          <textarea
+            value={bodyText}
+            onChange={(e) => setBodyText(e.target.value)}
+            rows={5}
+            placeholder="ここに回答を入力してください"
+            className="textarea textarea-bordered w-full"
+            required
+          />
+        </div>
+      )}
+
+      {/* 選択肢型 */}
+      {question.question_type === 'choice' && (
+        <div className="form-control">
+          <p className="label-text font-semibold mb-3">選択肢を選んでください</p>
+          <div className="space-y-2">
+            {(question.choices || []).map((choice) => (
+              <label key={choice.id} className="label cursor-pointer justify-start gap-4 py-2">
+                <input
+                  type="radio"
+                  name="choice_id"
+                  value={choice.id}
+                  checked={selectedChoiceId === String(choice.id)}
+                  onChange={() => setSelectedChoiceId(String(choice.id))}
+                  className="radio radio-primary"
+                  required
+                />
+                <span className="label-text text-base">{choice.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 評価型 */}
+      {question.question_type === 'rating' && (
+        <div className="form-control">
+          <p className="label-text font-semibold mb-3">評価を選んでください</p>
+          <div className="bg-base-200 rounded-xl p-4 border border-base-300 inline-flex flex-col gap-2">
+            <div className="flex gap-1">
+              {[1, 2, 3, 4, 5].map((value) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => setRatingValue(value)}
+                  className={`btn btn-ghost btn-sm text-2xl p-1 ${ratingValue >= value ? 'text-warning' : 'text-base-content/30'}`}
+                  aria-label={`${value} 点`}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
+            {ratingValue > 0 && (
+              <p className="text-sm text-center text-base-content/70">{ratingValue} 点を選択中</p>
+            )}
+          </div>
+          <p className="text-xs text-base-content/70 mt-2">1（低い）〜5（高い）で評価してください</p>
+        </div>
+      )}
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="btn btn-primary"
+        >
+          {submitting ? <span className="loading loading-spinner loading-sm" /> : null}
+          回答を送信
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default AnswerForm;

--- a/app/javascript/components/QuestionForm.jsx
+++ b/app/javascript/components/QuestionForm.jsx
@@ -1,0 +1,238 @@
+import React, { useState } from 'react';
+
+/**
+ * QuestionForm - 質問作成・編集フォームコンポーネント
+ * Admin が質問を作成/編集するための React フォーム
+ */
+const QuestionForm = ({ question = null, companyId, onSuccess, onCancel }) => {
+  const isEdit = !!question;
+
+  const [formData, setFormData] = useState({
+    title: question?.title || '',
+    body: question?.body || '',
+    question_type: question?.question_type || 'text',
+    status: question?.status || 'draft',
+    choices: question?.choices || [],
+  });
+
+  const [errors, setErrors] = useState([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleChoiceChange = (index, value) => {
+    const updated = [...formData.choices];
+    updated[index] = { ...updated[index], label: value };
+    setFormData((prev) => ({ ...prev, choices: updated }));
+  };
+
+  const addChoice = () => {
+    setFormData((prev) => ({
+      ...prev,
+      choices: [...prev.choices, { label: '' }],
+    }));
+  };
+
+  const removeChoice = (index) => {
+    const updated = formData.choices.filter((_, i) => i !== index);
+    setFormData((prev) => ({ ...prev, choices: updated }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setErrors([]);
+
+    const url = isEdit
+      ? `/admin/questions/${question.id}`
+      : '/admin/questions';
+    const method = isEdit ? 'PATCH' : 'POST';
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    try {
+      const res = await fetch(url, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': csrfToken,
+        },
+        body: JSON.stringify({
+          question: {
+            ...formData,
+            company_id: companyId,
+            choices_attributes: formData.choices.map((c) => ({
+              id: c.id,
+              label: c.label,
+              _destroy: c._destroy,
+            })),
+          },
+        }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        setErrors(data.errors || ['保存に失敗しました。']);
+      } else {
+        onSuccess?.(data.question);
+      }
+    } catch {
+      setErrors(['通信エラーが発生しました。']);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const needsChoices = formData.question_type === 'choice' || formData.question_type === 'rating';
+
+  return (
+    <div className="card bg-base-100 shadow-lg">
+      <div className="card-body">
+        <h2 className="card-title text-xl mb-4">
+          {isEdit ? '質問を編集' : '新しい質問を作成'}
+        </h2>
+
+        {errors.length > 0 && (
+          <div className="alert alert-error mb-4">
+            <ul className="list-disc list-inside">
+              {errors.map((err, i) => (
+                <li key={i}>{err}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* タイトル */}
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-semibold">タイトル <span className="text-error">*</span></span>
+            </label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              placeholder="質問のタイトルを入力"
+              className="input input-bordered w-full"
+              required
+            />
+          </div>
+
+          {/* 本文 */}
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-semibold">本文 <span className="text-error">*</span></span>
+            </label>
+            <textarea
+              name="body"
+              value={formData.body}
+              onChange={handleChange}
+              placeholder="質問の詳細を入力"
+              rows={4}
+              className="textarea textarea-bordered w-full"
+              required
+            />
+          </div>
+
+          {/* 質問タイプ */}
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-semibold">質問タイプ</span>
+            </label>
+            <select
+              name="question_type"
+              value={formData.question_type}
+              onChange={handleChange}
+              className="select select-bordered w-full"
+            >
+              <option value="text">テキスト（自由記述）</option>
+              <option value="choice">選択肢</option>
+              <option value="rating">評価（1〜5点）</option>
+            </select>
+          </div>
+
+          {/* 選択肢 */}
+          {needsChoices && (
+            <div className="form-control">
+              <label className="label">
+                <span className="label-text font-semibold">選択肢</span>
+              </label>
+              <div className="space-y-2">
+                {formData.choices.map((choice, index) => (
+                  <div key={index} className="flex gap-2 items-center">
+                    <input
+                      type="text"
+                      value={choice.label}
+                      onChange={(e) => handleChoiceChange(index, e.target.value)}
+                      placeholder={`選択肢 ${index + 1}`}
+                      className="input input-bordered flex-1"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeChoice(index)}
+                      className="btn btn-ghost btn-sm text-error"
+                    >
+                      削除
+                    </button>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={addChoice}
+                  className="btn btn-outline btn-sm"
+                >
+                  + 選択肢を追加
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* ステータス */}
+          <div className="form-control">
+            <label className="label">
+              <span className="label-text font-semibold">ステータス</span>
+            </label>
+            <select
+              name="status"
+              value={formData.status}
+              onChange={handleChange}
+              className="select select-bordered w-full"
+            >
+              <option value="draft">下書き</option>
+              <option value="published">公開</option>
+              <option value="closed">クローズ</option>
+            </select>
+          </div>
+
+          {/* ボタン */}
+          <div className="card-actions justify-end gap-2 mt-6">
+            {onCancel && (
+              <button
+                type="button"
+                onClick={onCancel}
+                className="btn btn-ghost"
+              >
+                キャンセル
+              </button>
+            )}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="btn btn-primary"
+            >
+              {submitting ? <span className="loading loading-spinner loading-sm" /> : null}
+              {isEdit ? '更新する' : '作成する'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionForm;

--- a/app/javascript/components/StatsDashboard.jsx
+++ b/app/javascript/components/StatsDashboard.jsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect, useRef } from 'react';
+
+/**
+ * StatsDashboard - 統計ダッシュボードコンポーネント
+ * 質問の回答統計を Chart.js で可視化する
+ * - 選択肢/評価型: 棒グラフ + 円グラフ
+ * - テキスト型: 自由記述一覧
+ */
+const StatsDashboard = ({ questionId }) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const barChartRef = useRef(null);
+  const pieChartRef = useRef(null);
+  const barChartInstance = useRef(null);
+  const pieChartInstance = useRef(null);
+
+  useEffect(() => {
+    fetchStats();
+  }, [questionId]);
+
+  useEffect(() => {
+    if (!data) return;
+    if (data.question.question_type === 'choice' || data.question.question_type === 'rating') {
+      renderCharts();
+    }
+    return () => {
+      barChartInstance.current?.destroy();
+      pieChartInstance.current?.destroy();
+    };
+  }, [data]);
+
+  const fetchStats = async () => {
+    try {
+      const res = await fetch(`/admin/questions/${questionId}/statistics.json`);
+      if (!res.ok) throw new Error('データの取得に失敗しました。');
+      const json = await res.json();
+      setData(json);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderCharts = () => {
+    if (!window.Chart) return;
+
+    const { charts, choice_stats: choiceStats } = data;
+    if (!charts || !choiceStats?.length) return;
+
+    // 棒グラフ
+    if (barChartRef.current) {
+      barChartInstance.current?.destroy();
+      barChartInstance.current = new window.Chart(barChartRef.current, {
+        type: 'bar',
+        data: {
+          labels: choiceStats.map((c) => c.label),
+          datasets: [
+            {
+              label: '回答数',
+              data: choiceStats.map((c) => c.count),
+              backgroundColor: charts.colors || '#3B82F6',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: { legend: { display: false } },
+          scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } },
+        },
+      });
+    }
+
+    // 円グラフ
+    if (pieChartRef.current) {
+      pieChartInstance.current?.destroy();
+      pieChartInstance.current = new window.Chart(pieChartRef.current, {
+        type: 'pie',
+        data: {
+          labels: choiceStats.map((c) => c.label),
+          datasets: [
+            {
+              data: choiceStats.map((c) => c.rate),
+              backgroundColor: charts.colors || [],
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            tooltip: {
+              callbacks: {
+                label: (ctx) => `${ctx.label}: ${ctx.parsed.toFixed(1)}%`,
+              },
+            },
+          },
+        },
+      });
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center py-16">
+        <span className="loading loading-spinner loading-lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="alert alert-error">
+        <span>{error}</span>
+      </div>
+    );
+  }
+
+  const { question, stats, answers, choice_stats: choiceStats } = data;
+  const isChoiceOrRating = question.question_type === 'choice' || question.question_type === 'rating';
+
+  return (
+    <div className="space-y-6">
+      {/* 統計サマリー */}
+      <div className="stats stats-horizontal shadow w-full">
+        <div className="stat">
+          <div className="stat-title">総回答数</div>
+          <div className="stat-value text-primary">{stats.total_answers}</div>
+        </div>
+        <div className="stat">
+          <div className="stat-title">回答率</div>
+          <div className="stat-value text-secondary">{stats.answer_rate}%</div>
+        </div>
+        {question.question_type === 'rating' && stats.average_rating != null && (
+          <div className="stat">
+            <div className="stat-title">平均評価</div>
+            <div className="stat-value text-accent">{stats.average_rating}</div>
+            <div className="stat-desc">/ 5.0</div>
+          </div>
+        )}
+      </div>
+
+      {/* 選択肢/評価型: グラフ */}
+      {isChoiceOrRating && choiceStats?.length > 0 && (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div className="card bg-base-100 shadow">
+              <div className="card-body">
+                <h3 className="card-title text-base">回答分布（棒グラフ）</h3>
+                <div style={{ height: 280, position: 'relative' }}>
+                  <canvas ref={barChartRef} />
+                </div>
+              </div>
+            </div>
+            <div className="card bg-base-100 shadow">
+              <div className="card-body">
+                <h3 className="card-title text-base">回答比率（円グラフ）</h3>
+                <div style={{ height: 280, position: 'relative' }}>
+                  <canvas ref={pieChartRef} />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 選択肢別統計テーブル */}
+          <div className="card bg-base-100 shadow">
+            <div className="card-body">
+              <h3 className="card-title text-base mb-4">選択肢別統計</h3>
+              <div className="overflow-x-auto">
+                <table className="table table-zebra w-full">
+                  <thead>
+                    <tr>
+                      <th>選択肢</th>
+                      <th className="text-right">回答数</th>
+                      <th className="text-right">回答率</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {choiceStats.map((choice) => (
+                      <tr key={choice.id}>
+                        <td>{choice.label}</td>
+                        <td className="text-right">{choice.count}</td>
+                        <td className="text-right">{choice.rate}%</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* テキスト型: 自由記述一覧 */}
+      {question.question_type === 'text' && (
+        <div className="card bg-base-100 shadow">
+          <div className="card-body">
+            <h3 className="card-title text-base mb-4">
+              自由記述回答一覧
+              <span className="badge badge-ghost ml-2">{answers?.length || 0}件</span>
+            </h3>
+            {answers?.length > 0 ? (
+              <div className="space-y-3">
+                {answers.map((answer) => (
+                  <div key={answer.id} className="bg-base-200 rounded-lg p-4 border border-base-300">
+                    <p className="text-sm whitespace-pre-wrap">{answer.body}</p>
+                    <p className="text-xs text-base-content/40 mt-2">
+                      {new Date(answer.created_at).toLocaleString('ja-JP')}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-base-content/50 text-sm">回答はまだありません。</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StatsDashboard;

--- a/app/views/member/questions/index.html.erb
+++ b/app/views/member/questions/index.html.erb
@@ -1,0 +1,70 @@
+<div class="container mx-auto py-8">
+  <div class="mb-4">
+    <%= link_to '← ダッシュボードに戻る', member_dashboard_path, class: 'link link-primary text-sm' %>
+  </div>
+
+  <h1 class="text-3xl font-bold mb-6">質問一覧</h1>
+
+  <!-- タブ -->
+  <div role="tablist" class="tabs tabs-bordered mb-6">
+    <%= link_to '未回答', member_questions_path(tab: 'unanswered'),
+        role: 'tab',
+        class: "tab #{@tab == 'unanswered' || @tab.nil? ? 'tab-active' : ''}" %>
+    <%= link_to '回答済み', member_questions_path(tab: 'answered'),
+        role: 'tab',
+        class: "tab #{@tab == 'answered' ? 'tab-active' : ''}" %>
+    <%= link_to 'クローズ済み', member_questions_path(tab: 'closed'),
+        role: 'tab',
+        class: "tab #{@tab == 'closed' ? 'tab-active' : ''}" %>
+  </div>
+
+  <% if @questions.any? %>
+    <div class="space-y-4">
+      <% @questions.each do |question| %>
+        <div class="card bg-base-100 shadow border border-base-300">
+          <div class="card-body">
+            <h2 class="card-title text-lg"><%= question.title %></h2>
+            <p class="text-sm text-base-content/70 line-clamp-2"><%= question.body %></p>
+            <div class="card-actions justify-between items-center mt-2">
+              <div class="flex gap-2">
+                <span class="badge badge-outline">
+                  <%= case question.question_type
+                      when 'text' then 'テキスト'
+                      when 'choice' then '選択肢'
+                      when 'rating' then '評価'
+                      end %>
+                </span>
+                <% if question.closed? %>
+                  <span class="badge badge-neutral">クローズ済み</span>
+                <% end %>
+              </div>
+              <% if @tab == 'answered' %>
+                <span class="badge badge-success">回答済み</span>
+              <% elsif @tab == 'closed' %>
+                <span class="text-sm text-base-content/50">回答期間終了</span>
+              <% else %>
+                <%= link_to '回答する', member_question_path(question), class: 'btn btn-sm btn-primary' %>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="alert alert-info">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+      </svg>
+      <span>
+        <% case @tab
+           when 'answered' %>
+          回答済みの質問はありません。
+        <% when 'closed' %>
+          クローズ済みの質問はありません。
+        <% else %>
+          現在回答可能な質問はありません。
+        <% end %>
+      </span>
+    </div>
+  <% end %>
+</div>

--- a/app/views/member/questions/show.html.erb
+++ b/app/views/member/questions/show.html.erb
@@ -1,0 +1,83 @@
+<div class="container mx-auto py-8 max-w-2xl">
+  <div class="mb-4">
+    <%= link_to '← 質問一覧に戻る', member_questions_path, class: 'link link-primary text-sm' %>
+  </div>
+
+  <div class="card bg-base-100 shadow-xl">
+    <div class="card-body">
+      <div class="flex items-center gap-2 mb-2">
+        <span class="badge badge-outline">
+          <%= case @question.question_type
+              when 'text' then 'テキスト'
+              when 'choice' then '選択肢'
+              when 'rating' then '評価'
+              end %>
+        </span>
+        <span class="badge badge-ghost text-xs">匿名回答</span>
+      </div>
+
+      <h1 class="card-title text-2xl mb-2"><%= @question.title %></h1>
+      <p class="text-base-content/70 mb-6 whitespace-pre-wrap"><%= @question.body %></p>
+
+      <% if @already_answered %>
+        <div class="alert alert-success">
+          <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <span>この質問にはすでに回答済みです。</span>
+        </div>
+      <% else %>
+        <%= form_with model: [@question, @answer], url: question_answers_path(@question, format: :html), local: true do |f| %>
+          <% if @answer.errors.any? %>
+            <div class="alert alert-error mb-4">
+              <ul class="list-disc list-inside">
+                <% @answer.errors.full_messages.each do |msg| %>
+                  <li><%= msg %></li>
+                <% end %>
+              </ul>
+            </div>
+          <% end %>
+
+          <% if @question.text? %>
+            <div class="form-control mb-6">
+              <%= f.label :body, '回答', class: 'label label-text font-semibold' %>
+              <%= f.text_area :body, rows: 5, placeholder: 'ここに回答を入力してください', class: 'textarea textarea-bordered w-full' %>
+            </div>
+
+          <% elsif @question.choice? %>
+            <div class="form-control mb-6">
+              <p class="label-text font-semibold mb-3">選択肢を選んでください</p>
+              <% @question.choices.each do |choice| %>
+                <label class="label cursor-pointer justify-start gap-4 py-2">
+                  <%= f.radio_button :choice_id, choice.id, class: 'radio radio-primary' %>
+                  <span class="label-text text-base"><%= choice.label %></span>
+                </label>
+              <% end %>
+            </div>
+
+          <% elsif @question.rating? %>
+            <div class="form-control mb-6">
+              <p class="label-text font-semibold mb-3">評価を選んでください</p>
+              <div class="bg-base-200 rounded-xl p-4 border border-base-300 inline-block">
+                <div class="rating rating-lg gap-1">
+                  <input type="radio" name="answer[rating_value]" value="" class="rating-hidden" />
+                  <% (1..5).each do |value| %>
+                    <%= radio_button_tag 'answer[rating_value]', value, false, class: 'mask mask-star-2 bg-warning', aria: { label: "#{value} 点" } %>
+                  <% end %>
+                </div>
+              </div>
+              <p class="text-xs text-base-content/70 mt-2">1（低い）〜5（高い）で評価してください</p>
+              <%= f.hidden_field :choice_id, value: '' %>
+            </div>
+          <% end %>
+
+          <%= f.hidden_field :session_id, value: session.id.to_s %>
+
+          <div class="card-actions justify-end mt-4">
+            <%= f.submit '回答を送信', class: 'btn btn-primary' %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,12 +36,16 @@ Rails.application.routes.draw do
     resources :questions do
       resources :choices, only: [:create, :update, :destroy]
       get 'statistics', to: 'statistics#show', as: :statistics
+      resources :answers, only: [] do
+        resources :admin_replies, only: [:index, :create, :destroy]
+      end
     end
   end
 
   # Member namespace
   namespace :member, path: 'member' do
     get 'dashboard', to: 'dashboard#index', as: :dashboard
+    resources :questions, only: [:index, :show]
     resources :answers, only: [:index]
   end
 

--- a/spec/factories/admin_replies.rb
+++ b/spec/factories/admin_replies.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :admin_reply do
+    association :answer
+    association :user
+    reply_text { Faker::Lorem.paragraph(sentence_count: 2) }
+    status { :draft }
+  end
+end

--- a/spec/requests/admin_admin_replies_spec.rb
+++ b/spec/requests/admin_admin_replies_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::AdminReplies', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin_user) { create(:user, :admin) }
+  let(:member_user) { create(:user, :member) }
+  let(:company) { create(:company, owner_id: admin_user.id) }
+  let(:question) { create(:question, :published, company: company) }
+  let(:answer) { create(:answer, question: question, body: 'テスト回答') }
+
+  describe 'アクセス制御' do
+    context '未認証ユーザー' do
+      it 'ログインページにリダイレクトされる' do
+        get "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'memberユーザー' do
+      before { sign_in member_user }
+
+      it 'admin_replies にアクセスできない' do
+        get "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies"
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context 'adminユーザー' do
+      before { sign_in admin_user }
+
+      it 'admin_replies にアクセスできる' do
+        get "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies.json"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'GET /admin/questions/:question_id/answers/:answer_id/admin_replies' do
+    before { sign_in admin_user }
+
+    context '返信がない場合' do
+      it '空の配列を返す' do
+        get "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies.json"
+        json = JSON.parse(response.body)
+        expect(json['admin_replies']).to be_an(Array)
+        expect(json['admin_replies']).to be_empty
+      end
+    end
+
+    context '返信がある場合' do
+      before do
+        create(:admin_reply, answer: answer, user: admin_user, reply_text: '対応します')
+        create(:admin_reply, answer: answer, user: admin_user, reply_text: '確認しました')
+      end
+
+      it '返信一覧を返す' do
+        get "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies.json"
+        json = JSON.parse(response.body)
+        expect(json['admin_replies'].length).to eq(2)
+        expect(json['admin_replies'].first).to include('reply_text', 'status')
+      end
+    end
+  end
+
+  describe 'POST /admin/questions/:question_id/answers/:answer_id/admin_replies' do
+    before { sign_in admin_user }
+
+    let(:valid_params) do
+      { admin_reply: { reply_text: '確認しました。対応します。', status: 'published' } }
+    end
+
+    context '正常なパラメータ' do
+      it '返信が作成される' do
+        expect {
+          post "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies",
+               params: valid_params, as: :json
+        }.to change(AdminReply, :count).by(1)
+      end
+
+      it 'HTTP 201 を返す' do
+        post "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies",
+             params: valid_params, as: :json
+        expect(response).to have_http_status(:created)
+      end
+
+      it '作成した返信を返す' do
+        post "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies",
+             params: valid_params, as: :json
+        json = JSON.parse(response.body)
+        expect(json['admin_reply']['reply_text']).to eq('確認しました。対応します。')
+      end
+
+      it 'admin_user が user として設定される' do
+        post "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies",
+             params: valid_params, as: :json
+        expect(AdminReply.last.user).to eq(admin_user)
+      end
+    end
+
+    context '不正なパラメータ' do
+      it 'reply_text が空の場合はエラーを返す' do
+        post "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies",
+             params: { admin_reply: { reply_text: '' } }, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        json = JSON.parse(response.body)
+        expect(json['errors']).to be_present
+      end
+    end
+  end
+
+  describe 'DELETE /admin/questions/:question_id/answers/:answer_id/admin_replies/:id' do
+    before { sign_in admin_user }
+
+    let!(:admin_reply) do
+      create(:admin_reply, answer: answer, user: admin_user, reply_text: '削除テスト')
+    end
+
+    it '返信が削除される' do
+      expect {
+        delete "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies/#{admin_reply.id}",
+               as: :json
+      }.to change(AdminReply, :count).by(-1)
+    end
+
+    it 'HTTP 204 を返す' do
+      delete "/admin/questions/#{question.id}/answers/#{answer.id}/admin_replies/#{admin_reply.id}",
+             as: :json
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+end

--- a/spec/requests/member_questions_spec.rb
+++ b/spec/requests/member_questions_spec.rb
@@ -1,0 +1,131 @@
+require 'rails_helper'
+
+RSpec.describe 'Member::Questions', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:admin_user) { create(:user, :admin) }
+  let(:member_user) { create(:user, :member) }
+  let(:company) { create(:company, owner_id: admin_user.id) }
+
+  before do
+    # member_user を company に所属させる
+    create(:company_member, company: company, user: member_user, role: :member)
+  end
+
+  describe 'アクセス制御' do
+    context '未認証ユーザー' do
+      it 'ログインページにリダイレクトされる' do
+        get '/member/questions'
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context 'adminユーザー' do
+      before { sign_in admin_user }
+
+      it 'adminダッシュボードにリダイレクトされる' do
+        get '/member/questions'
+        expect(response).to redirect_to(admin_dashboard_path)
+      end
+    end
+
+    context 'memberユーザー' do
+      before { sign_in member_user }
+
+      it 'HTTP 200 を返す' do
+        get '/member/questions'
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  describe 'GET /member/questions (未回答タブ)' do
+    before { sign_in member_user }
+
+    let!(:published_q1) { create(:question, :published, company: company, title: '質問1') }
+    let!(:published_q2) { create(:question, :published, company: company, title: '質問2') }
+    let!(:draft_q) { create(:question, company: company, title: '下書き質問') }
+    let!(:closed_q) { create(:question, :closed, company: company, title: 'クローズ質問') }
+
+    context 'tab=unanswered（デフォルト）' do
+      it '公開中で未回答の質問のみを返す' do
+        get '/member/questions', params: { tab: 'unanswered' }
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('質問1')
+        expect(response.body).to include('質問2')
+        expect(response.body).not_to include('下書き質問')
+      end
+
+      it 'JSON フォーマットで質問リストを返す' do
+        get '/member/questions.json', params: { tab: 'unanswered' }
+        json = JSON.parse(response.body)
+        expect(json['questions']).to be_an(Array)
+        unanswered_titles = json['questions'].map { |q| q['title'] }
+        expect(unanswered_titles).to include('質問1', '質問2')
+        expect(unanswered_titles).not_to include('下書き質問')
+      end
+    end
+
+    context 'tab=answered' do
+      before do
+        create(:answer, question: published_q1, user: member_user,
+               session_id: "session_#{member_user.id}")
+      end
+
+      it '回答済みの質問のみを返す' do
+        get '/member/questions.json', params: { tab: 'answered' }
+        json = JSON.parse(response.body)
+        titles = json['questions'].map { |q| q['title'] }
+        expect(titles).to include('質問1')
+        expect(titles).not_to include('質問2')
+      end
+    end
+
+    context 'tab=closed' do
+      it 'クローズ済みの質問のみを返す' do
+        get '/member/questions.json', params: { tab: 'closed' }
+        json = JSON.parse(response.body)
+        titles = json['questions'].map { |q| q['title'] }
+        expect(titles).to include('クローズ質問')
+        expect(titles).not_to include('質問1')
+      end
+    end
+  end
+
+  describe 'GET /member/questions/:id (質問詳細 + 回答フォーム)' do
+    before { sign_in member_user }
+
+    let!(:question) { create(:question, :published, company: company, title: '詳細質問') }
+
+    it 'HTTP 200 を返す' do
+      get "/member/questions/#{question.id}"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it '質問タイトルが表示される' do
+      get "/member/questions/#{question.id}"
+      expect(response.body).to include('詳細質問')
+    end
+
+    context 'すでに回答済みの場合' do
+      before do
+        create(:answer, question: question, user: member_user,
+               session_id: "session_#{member_user.id}")
+      end
+
+      it '回答済みと表示される' do
+        get "/member/questions/#{question.id}"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'クローズされた質問' do
+      let!(:closed_q) { create(:question, :closed, company: company) }
+
+      it 'ダッシュボードにリダイレクトされる' do
+        get "/member/questions/#{closed_q.id}"
+        expect(response).to redirect_to(member_dashboard_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #29 に対応する Phase3 実装。

## 実装内容

### Controllers
- `Admin::AdminRepliesController` - 管理者による回答への返信
- `Member::QuestionsController` - タブ付き質問一覧（未回答/回答済み/クローズ済み）

### 画面
- 質問一覧（未回答/回答済み/クローズ済みタブ）
- 回答フォーム（question_type 別入力）
- 統計画面（Chart.js グラフ付き）

### React Components
- `QuestionForm.jsx` - 質問作成・編集フォーム
- `AnswerForm.jsx` - 回答フォーム
- `StatsDashboard.jsx` - 統計ダッシュボード（Chart.js）

## 受け入れ条件
- [ ] admin以上のみ質問作成/編集/公開切替可能
- [ ] memberのみ回答可能
- [ ] 統計表示が権限/公開設定に従う
- [ ] 回答は匿名設計を維持
- [ ] Chart.js の選択肢グラフが表示される

Closes #29