### PR TITLE
feat(issue-30): Phase4 Claude API分析・Sidekiqジョブ・リマインダーメール実装

### DIFF
--- a/app/jobs/analysis_job.rb
+++ b/app/jobs/analysis_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AnalysisJob < ApplicationJob
+  queue_as :default
+
+  def perform(question_id)
+    question = Question.find(question_id)
+    AnalysisService.new(question: question).call
+  end
+end

--- a/app/jobs/recurring_job.rb
+++ b/app/jobs/recurring_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RecurringJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    enqueue_deadline_reminders(3)
+    enqueue_deadline_reminders(1)
+
+    RecurringSchedule.active_schedules.due_today.find_each do |schedule|
+      AnalysisJob.perform_later(schedule.question_id) if schedule.question_id.present?
+      schedule.mark_as_run
+    end
+  end
+
+  private
+
+  def enqueue_deadline_reminders(days_before_deadline)
+    target_date = days_before_deadline.days.from_now.to_date
+    range = target_date.beginning_of_day..target_date.end_of_day
+
+    Question.published.where(deadline: range).find_each do |question|
+      ReminderJob.perform_later(question.id, days_before_deadline)
+    end
+  end
+end

--- a/app/jobs/reminder_job.rb
+++ b/app/jobs/reminder_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ReminderJob < ApplicationJob
+  queue_as :mailers
+
+  def perform(question_id, days_before_deadline)
+    question = Question.find(question_id)
+    return if question.deadline.blank?
+
+    answered_user_ids = question.answers.where.not(user_id: nil).distinct.pluck(:user_id)
+
+    question.company.users.where(notification_enabled: true).where.not(id: answered_user_ids).find_each do |user|
+      ReminderMailer.question_reminder(user, question, days_before_deadline).deliver_later
+    end
+  end
+end

--- a/app/mailers/reminder_mailer.rb
+++ b/app/mailers/reminder_mailer.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ReminderMailer < ApplicationMailer
+  def question_reminder(user, question, days_before_deadline)
+    @user = user
+    @question = question
+    @days_before_deadline = days_before_deadline
+
+    mail(
+      to: @user.email,
+      subject: "【Honest Voice】「#{@question.title}」の回答締切まであと#{@days_before_deadline}日です"
+    )
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -27,4 +27,8 @@ class Question < ApplicationRecord
   def closed?
     status == 'closed'
   end
+
+  def eligible_for_analysis?
+    answers.count >= 5
+  end
 end

--- a/app/models/question_analysis.rb
+++ b/app/models/question_analysis.rb
@@ -4,9 +4,12 @@ class QuestionAnalysis < ApplicationRecord
   belongs_to :question
   belongs_to :company
 
+  enum :status, { pending: 0, processing: 1, completed: 2, failed: 3 }
+
   validates :question_id, presence: true
   validates :company_id, presence: true
   validates :question_id, uniqueness: { scope: :company_id }
+  validates :status, presence: true
 
   def keywords_array
     keywords.present? ? keywords.split(',').map(&:strip) : []

--- a/app/services/analysis_service.rb
+++ b/app/services/analysis_service.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+class AnalysisService
+  MINIMUM_RESPONSES = 5
+  MODEL_NAME = 'claude-opus-4-5'
+
+  def initialize(question:, client: nil)
+    @question = question
+    @client = client || default_client
+  end
+
+  def call
+    analysis = ensure_analysis_record
+    analysis.update!(total_responses: @question.answers.count)
+    return analysis unless @question.eligible_for_analysis?
+
+    analysis.processing!
+    parsed = parse_response(create_message)
+
+    analysis.update!(
+      sentiment_summary: parsed[:sentiment_summary],
+      average_rating: parsed[:average_rating].to_f,
+      total_responses: parsed[:total_responses].to_i,
+      analyzed_at: Time.current,
+      status: :completed
+    )
+    analysis.keywords_array = Array(parsed[:keywords]).map(&:to_s)
+    analysis.save!
+    analysis
+  rescue StandardError
+    analysis ||= ensure_analysis_record
+    analysis.update(status: :failed, total_responses: @question.answers.count)
+    analysis
+  end
+
+  private
+
+  def ensure_analysis_record
+    QuestionAnalysis.find_or_create_by!(question: @question, company: @question.company) do |analysis|
+      analysis.status = :pending
+      analysis.total_responses = @question.answers.count
+    end
+  end
+
+  def create_message
+    @client.messages.create(
+      model: MODEL_NAME,
+      max_tokens: 800,
+      messages: [
+        {
+          role: 'user',
+          content: build_prompt
+        }
+      ]
+    )
+  end
+
+  def build_prompt
+    <<~PROMPT
+      次のアンケート回答を分析し、JSONのみで返してください。
+      keys は sentiment_summary, keywords, average_rating, total_responses です。
+
+      質問タイトル: #{@question.title}
+      質問本文: #{@question.body}
+      質問タイプ: #{@question.question_type}
+      回答数: #{@question.answers.count}
+
+      回答一覧:
+      #{formatted_answers}
+    PROMPT
+  end
+
+  def formatted_answers
+    @question.answers.includes(:choice).order(:created_at).map do |answer|
+      if answer.body.present?
+        "- #{answer.body}"
+      elsif answer.choice.present?
+        "- #{answer.choice.label}"
+      else
+        '- 回答なし'
+      end
+    end.join("\n")
+  end
+
+  def parse_response(response)
+    content = extract_content(response)
+    text = Array(content).find { |item| content_text(item).present? }
+    JSON.parse(content_text(text), symbolize_names: true)
+  end
+
+  def extract_content(response)
+    return response['content'] if response.is_a?(Hash)
+    return response[:content] if response.is_a?(Hash)
+
+    response.content
+  end
+
+  def content_text(item)
+    return if item.blank?
+    return item['text'] if item.is_a?(Hash)
+    return item[:text] if item.respond_to?(:[]) && item[:text]
+
+    item.respond_to?(:text) ? item.text : nil
+  end
+
+  def default_client
+    api_key = ENV['ANTHROPIC_API_KEY']
+    raise 'ANTHROPIC_API_KEY is not configured' if api_key.blank?
+
+    Anthropic::Client.new(access_token: api_key)
+  end
+end

--- a/app/views/reminder_mailer/question_reminder.html.erb
+++ b/app/views/reminder_mailer/question_reminder.html.erb
@@ -1,0 +1,9 @@
+<p><%= @user.name.presence || @user.email %> 様</p>
+
+<p>「<strong><%= @question.title %></strong>」の回答締切まであと<%= @days_before_deadline %>日です。</p>
+
+<p><%= simple_format(@question.body) %></p>
+
+<p>回答済みの方はご無視ください。</p>
+
+<p>Honest Voice</p>

--- a/app/views/reminder_mailer/question_reminder.text.erb
+++ b/app/views/reminder_mailer/question_reminder.text.erb
@@ -1,0 +1,10 @@
+<%= @user.name.presence || @user.email %> 様
+
+「<%= @question.title %>」の回答締切まであと<%= @days_before_deadline %>日です。
+
+質問内容:
+<%= @question.body %>
+
+回答済みの方はご無視ください。
+
+Honest Voice

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+redis_url = ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: redis_url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: redis_url }
+end
+
+Rails.application.config.active_job.queue_adapter = :sidekiq

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,5 @@
+set :output, 'log/cron.log'
+
+every 1.day, at: '9:00 am' do
+  runner 'RecurringJob.perform_later'
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 5
+:queues:
+  - default
+  - mailers

--- a/db/migrate/20260504000015_add_status_to_question_analyses.rb
+++ b/db/migrate/20260504000015_add_status_to_question_analyses.rb
@@ -1,0 +1,5 @@
+class AddStatusToQuestionAnalyses < ActiveRecord::Migration[8.1]
+  def change
+    add_column :question_analyses, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_000014) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_000015) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -125,6 +125,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_000014) do
     t.text "keywords"
     t.bigint "question_id", null: false
     t.text "sentiment_summary"
+    t.integer "status", default: 0, null: false
     t.integer "total_responses", default: 0
     t.datetime "updated_at", null: false
     t.index ["company_id"], name: "index_question_analyses_on_company_id"

--- a/spec/factories/question_analyses.rb
+++ b/spec/factories/question_analyses.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :question_analysis do
+    question
+    company { question.company }
+    status { 'pending' }
+    sentiment_summary { nil }
+    keywords { nil }
+    average_rating { 0.0 }
+    total_responses { 0 }
+    analyzed_at { nil }
+  end
+end

--- a/spec/factories/recurring_schedules.rb
+++ b/spec/factories/recurring_schedules.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :recurring_schedule do
+    company
+    question { nil }
+    sequence(:name) { |n| "Recurring Schedule #{n}" }
+    frequency { :monthly }
+    status { :active }
+    next_scheduled_at { Time.current }
+    last_run_at { nil }
+  end
+end

--- a/spec/jobs/analysis_job_spec.rb
+++ b/spec/jobs/analysis_job_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe AnalysisJob, type: :job do
+  let(:question) { create(:question, :text_type, :published) }
+  let(:service) { instance_double(AnalysisService, call: true) }
+
+  it 'AnalysisService を呼び出す' do
+    allow(AnalysisService).to receive(:new).with(question: question).and_return(service)
+
+    described_class.perform_now(question.id)
+
+    expect(service).to have_received(:call)
+  end
+end

--- a/spec/jobs/recurring_job_spec.rb
+++ b/spec/jobs/recurring_job_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe RecurringJob, type: :job do
+  let(:question) { create(:question, :published) }
+  let!(:due_schedule) { create(:recurring_schedule, question: question, next_scheduled_at: 1.hour.ago, status: :active) }
+  let!(:future_schedule) { create(:recurring_schedule, next_scheduled_at: 1.day.from_now, status: :active) }
+
+  it '期限到来済みのスケジュールだけを処理する' do
+    allow(AnalysisJob).to receive(:perform_later)
+
+    described_class.perform_now
+
+    expect(AnalysisJob).to have_received(:perform_later).with(question.id).at_most(:once)
+    expect(future_schedule.reload.last_run_at).to be_nil
+  end
+end

--- a/spec/jobs/reminder_job_spec.rb
+++ b/spec/jobs/reminder_job_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ReminderJob, type: :job do
+  let(:company) { create(:company) }
+  let(:question) { create(:question, :published, company: company, deadline: 3.days.from_now) }
+  let(:target_user) { create(:user, notification_enabled: true) }
+  let(:answered_user) { create(:user, notification_enabled: true) }
+  let(:muted_user) { create(:user, notification_enabled: false) }
+
+  before do
+    create(:company_member, company: company, user: target_user, role: :member)
+    create(:company_member, company: company, user: answered_user, role: :member)
+    create(:company_member, company: company, user: muted_user, role: :member)
+    create(:answer, question: question, company: company, user: answered_user, body: '回答済み')
+  end
+
+  it '未回答かつ通知有効ユーザーのみにリマインドを送る' do
+    delivery = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+    allow(ReminderMailer).to receive(:question_reminder).and_return(delivery)
+
+    described_class.perform_now(question.id, 3)
+
+    expect(ReminderMailer).to have_received(:question_reminder).with(target_user, question, 3)
+    expect(ReminderMailer).not_to have_received(:question_reminder).with(answered_user, question, 3)
+    expect(ReminderMailer).not_to have_received(:question_reminder).with(muted_user, question, 3)
+  end
+end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -7,14 +7,23 @@ RSpec.describe ReminderMailer, type: :mailer do
   describe '#question_reminder' do
     let(:mail) { described_class.question_reminder(user, question, 3) }
 
+    def decoded_mail_body(message)
+      if message.text_part
+        message.text_part.decoded
+      else
+        message.body.decoded
+      end
+    end
+
     it '宛先と件名を設定する' do
       expect(mail.to).to eq(['member@example.com'])
       expect(mail.subject).to include('回答お願いします')
     end
 
     it '回答済みの方はご無視くださいを本文に含める' do
-      expect(mail.body.encoded).to include('回答済みの方はご無視ください')
-      expect(mail.body.encoded).to include('3日')
+      body = decoded_mail_body(mail)
+      expect(body).to include('回答済みの方はご無視ください')
+      expect(body).to include('3日')
     end
   end
 end

--- a/spec/mailers/reminder_mailer_spec.rb
+++ b/spec/mailers/reminder_mailer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ReminderMailer, type: :mailer do
+  let(:user) { create(:user, email: 'member@example.com', name: 'Member User') }
+  let(:question) { create(:question, title: '回答お願いします', deadline: 3.days.from_now) }
+
+  describe '#question_reminder' do
+    let(:mail) { described_class.question_reminder(user, question, 3) }
+
+    it '宛先と件名を設定する' do
+      expect(mail.to).to eq(['member@example.com'])
+      expect(mail.subject).to include('回答お願いします')
+    end
+
+    it '回答済みの方はご無視くださいを本文に含める' do
+      expect(mail.body.encoded).to include('回答済みの方はご無視ください')
+      expect(mail.body.encoded).to include('3日')
+    end
+  end
+end

--- a/spec/services/analysis_service_spec.rb
+++ b/spec/services/analysis_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe AnalysisService do
+  let(:company) { create(:company) }
+  let(:question) { create(:question, :text_type, :published, company: company) }
+  let(:client) { instance_double(Anthropic::Client) }
+  let(:message_text) do
+    {
+      sentiment_summary: '全体として前向きだが、業務量に改善要望がある',
+      keywords: ['働き方', '業務量', 'コミュニケーション'],
+      average_rating: 4.2,
+      total_responses: 5
+    }.to_json
+  end
+  let(:api_response) do
+    {
+      'content' => [
+        { 'type' => 'text', 'text' => message_text }
+      ]
+    }
+  end
+
+  before do
+    5.times do |index|
+      create(:answer, question: question, company: company, body: "回答#{index}")
+    end
+  end
+
+  describe '#call' do
+    it '回答5件以上で QuestionAnalysis を completed まで更新する' do
+      allow(client).to receive(:messages).and_return(double(create: api_response))
+
+      analysis = described_class.new(question: question, client: client).call
+
+      expect(analysis).to be_completed
+      expect(analysis.sentiment_summary).to include('前向き')
+      expect(analysis.keywords_array).to include('働き方', '業務量')
+      expect(analysis.average_rating).to eq(4.2)
+      expect(analysis.total_responses).to eq(5)
+      expect(analysis.analyzed_at).to be_present
+    end
+
+    it '回答が5件未満なら pending のまま処理しない' do
+      question.answers.limit(2).destroy_all
+      allow(client).to receive(:messages)
+
+      analysis = described_class.new(question: question, client: client).call
+
+      expect(analysis).to be_pending
+      expect(client).not_to have_received(:messages)
+    end
+
+    it 'API エラー時は failed に遷移する' do
+      allow(client).to receive(:messages).and_raise(StandardError, 'api failure')
+
+      analysis = described_class.new(question: question, client: client).call
+
+      expect(analysis).to be_failed
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Issue #30 に対応する Phase4 実装。

## 実装内容

### 分析
- AnalysisService を追加
- Claude API を利用して QuestionAnalysis を更新

### Jobs
- AnalysisJob
- ReminderJob
- RecurringJob

### Mailer
- ReminderMailer
- 締切3日前/1日前の通知
- 回答済みユーザーと通知無効ユーザーの除外

### Sidekiq / Schedule
- Sidekiq 初期設定
- whenever による毎朝9時実行設定

## 受け入れ条件
- [ ] 回答5件以上でAI分析実行可能
- [ ] QuestionAnalysis.status が pending→processing→completed/failed で遷移
- [ ] 毎朝9時実行（whenever設定）
- [ ] notification_enabled=false のユーザーには送信しない
- [ ] bundle exec sidekiq でジョブ処理が動作する

Closes #30